### PR TITLE
Added "usergroups.collection.get" to "can view users"

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -109,6 +109,7 @@
       "subPermissions": ["users-bl.collection.get", "users-bl.item.get",
         "module.users.enabled",
         "users.collection.get", "users.item.get",
+        "usergroups.collection.get",
         "login.item.get"],
       "visible": true
     }, {


### PR DESCRIPTION
which gets included in most of the other logical permission sets,
so the bit should be available where needed