### PR TITLE
Remove groovy-eclipse from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,27 +101,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-          <compilerId>groovy-eclipse-compiler</compilerId>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-eclipse-compiler</artifactId>
-            <version>2.9.1-01</version>
-          </dependency>
-          <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-eclipse-batch</artifactId>
-            <version>2.3.7-01</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.5.0</version>


### PR DESCRIPTION
* There are no groovy files in this project.
* The Groovy-Eclipse configurator for m2eclipse is not compatible with AspectJ used for RAMLs: https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin