### PR TITLE
MODUSERBL-48: Fix module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -102,7 +102,7 @@
         },
         {
           "methods": ["POST"],
-          "pathPattern": "/forgotten/password",
+          "pathPattern": "/bl-users/forgotten/password",
           "permissionsDesired": [],
           "permissionsRequired": [],
           "modulePermissions": ["users.edit", "users.item.put",
@@ -111,7 +111,7 @@
         },
         {
           "methods": ["POST"],
-          "pathPattern": "/forgotten/username",
+          "pathPattern": "/bl-users/forgotten/username",
           "permissionsDesired": [],
           "permissionsRequired": [],
           "modulePermissions": ["users.edit", "users.item.put",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -107,7 +107,8 @@
           "permissionsRequired": [],
           "modulePermissions": ["users.edit", "users.item.put",
             "perms.users.item.put",
-            "login.item.put"]
+            "login.item.put",
+            "configuration.entries.item.get"]
         },
         {
           "methods": ["POST"],
@@ -116,7 +117,8 @@
           "permissionsRequired": [],
           "modulePermissions": ["users.edit", "users.item.put",
             "perms.users.item.put",
-            "login.item.put"]
+            "login.item.put",
+            "configuration.entries.item.get"]
         },
         {
           "methods": ["POST"],


### PR DESCRIPTION
1. Fixed mismatch between raml file and ModuleDescriptor.
2. Added "configuration.entries.item.get" permission for "/bl-users/forgotten/password" and "/bl-users/forgotten/username" endpoints.

Jira link: [MODUSERBL-48](https://issues.folio.org/browse/MODUSERBL-48)