### PR TITLE
MODUSERBL-48: Fix module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -108,7 +108,8 @@
           "modulePermissions": ["users.edit", "users.item.put",
             "perms.users.item.put",
             "login.item.put",
-            "configuration.entries.item.get"]
+            "configuration.entries.collection.get",
+            "users.collection.get" ]
         },
         {
           "methods": ["POST"],
@@ -118,7 +119,8 @@
           "modulePermissions": ["users.edit", "users.item.put",
             "perms.users.item.put",
             "login.item.put",
-            "configuration.entries.item.get"]
+            "configuration.entries.collection.get",
+            "users.collection.get" ]
         },
         {
           "methods": ["POST"],

--- a/pom.xml
+++ b/pom.xml
@@ -458,6 +458,7 @@
           <systemPropertyVariables>
             <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.SLF4JLogDelegateFactory</vertx.logger-delegate-factory-class-name>
           </systemPropertyVariables>
+          <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
1. Fixed mismatch between raml file and ModuleDescriptor.
2. Added "configuration.entries.collection.get"and "users.collection.get" permissions for "/bl-users/forgotten/password" and "/bl-users/forgotten/username" endpoints.

Jira link: [MODUSERBL-48](https://issues.folio.org/browse/MODUSERBL-48)