### PR TITLE
Temporarily allow additional properties in service points MODUSERBL-67 

### DIFF
--- a/ramls/servicepoint.json
+++ b/ramls/servicepoint.json
@@ -69,7 +69,6 @@
       "description": "Metadata"
     }
   },
-  "additionalProperties": false,
   "required": [
     "name",
     "code",

--- a/src/test/java/org/folio/rest/jaxrs/model/ServicePointTest.java
+++ b/src/test/java/org/folio/rest/jaxrs/model/ServicePointTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 
 import io.vertx.core.json.JsonObject;
 
@@ -38,7 +37,7 @@ public class ServicePointTest {
   }
 
   @Test
-  public void cannotDeserializeFromJsonWithUnexpectedProperties() throws IOException {
+  public void canDeserializeFromJsonWithUnexpectedProperties() throws IOException {
     final ObjectMapper mapper = ObjectMapperTool.getMapper();
 
     final JsonObject servicePointJson = new JsonObject();
@@ -47,8 +46,16 @@ public class ServicePointTest {
     servicePointJson.put("code", "cpA");
     servicePointJson.put("foo", "bar");
 
-    expectedExceptions.expect(UnrecognizedPropertyException.class);
+    final JsonObject expiryPeriod = new JsonObject();
+    expiryPeriod.put("duration", "1");
+    expiryPeriod.put("intervalId", "Weeks");
 
-    mapper.readValue(servicePointJson.encode(), ServicePoint.class);
+    servicePointJson.put("holdShelfExpiryPeriod", expiryPeriod);
+
+    final ServicePoint servicePoint = mapper.readValue(servicePointJson.encode(),
+      ServicePoint.class);
+
+    assertThat(servicePoint.getName(), is("Collection Point A"));
+    assertThat(servicePoint.getCode(), is("cpA"));
   }
 }

--- a/src/test/java/org/folio/rest/jaxrs/model/ServicePointTest.java
+++ b/src/test/java/org/folio/rest/jaxrs/model/ServicePointTest.java
@@ -1,0 +1,54 @@
+package org.folio.rest.jaxrs.model;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
+
+import org.folio.rest.tools.utils.ObjectMapperTool;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+
+import io.vertx.core.json.JsonObject;
+
+public class ServicePointTest {
+
+  @Rule
+  public ExpectedException expectedExceptions = ExpectedException.none();
+
+  @Test
+  public void canDeserializeFromJson() throws IOException {
+
+    final ObjectMapper mapper = ObjectMapperTool.getMapper();
+
+    final JsonObject servicePointJson = new JsonObject();
+
+    servicePointJson.put("name", "Collection Point A");
+    servicePointJson.put("code", "cpA");
+
+    final ServicePoint servicePoint = mapper.readValue(servicePointJson.encode(),
+      ServicePoint.class);
+
+    assertThat(servicePoint.getName(), is("Collection Point A"));
+    assertThat(servicePoint.getCode(), is("cpA"));
+  }
+
+  @Test
+  public void cannotDeserializeFromJsonWithUnexpectedProperties() throws IOException {
+    final ObjectMapper mapper = ObjectMapperTool.getMapper();
+
+    final JsonObject servicePointJson = new JsonObject();
+
+    servicePointJson.put("name", "Collection Point A");
+    servicePointJson.put("code", "cpA");
+    servicePointJson.put("foo", "bar");
+
+    expectedExceptions.expect(UnrecognizedPropertyException.class);
+
+    mapper.readValue(servicePointJson.encode(), ServicePoint.class);
+  }
+}

--- a/src/test/java/org/folio/rest/jaxrs/model/ServicePointTest.java
+++ b/src/test/java/org/folio/rest/jaxrs/model/ServicePointTest.java
@@ -1,6 +1,7 @@
 package org.folio.rest.jaxrs.model;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
@@ -21,29 +22,31 @@ public class ServicePointTest {
 
   @Test
   public void canDeserializeFromJson() throws IOException {
-
     final ObjectMapper mapper = ObjectMapperTool.getMapper();
 
     final JsonObject servicePointJson = new JsonObject();
 
     servicePointJson.put("name", "Collection Point A");
     servicePointJson.put("code", "cpA");
+    servicePointJson.put("discoveryDisplayName", "Coll Point A");
 
     final ServicePoint servicePoint = mapper.readValue(servicePointJson.encode(),
       ServicePoint.class);
 
     assertThat(servicePoint.getName(), is("Collection Point A"));
     assertThat(servicePoint.getCode(), is("cpA"));
+    assertThat(servicePoint.getDiscoveryDisplayName(), is("Coll Point A"));
   }
 
   @Test
-  public void canDeserializeFromJsonWithUnexpectedProperties() throws IOException {
+  public void canDeserializeFromJsonWithAdditionalProperties() throws IOException {
     final ObjectMapper mapper = ObjectMapperTool.getMapper();
 
     final JsonObject servicePointJson = new JsonObject();
 
     servicePointJson.put("name", "Collection Point A");
     servicePointJson.put("code", "cpA");
+    servicePointJson.put("discoveryDisplayName", "Coll Point A");
     servicePointJson.put("foo", "bar");
 
     final JsonObject expiryPeriod = new JsonObject();
@@ -57,5 +60,22 @@ public class ServicePointTest {
 
     assertThat(servicePoint.getName(), is("Collection Point A"));
     assertThat(servicePoint.getCode(), is("cpA"));
+    assertThat(servicePoint.getDiscoveryDisplayName(), is("Coll Point A"));
+  }
+
+  @Test
+  public void canDeserializeFromJsonWithoutRequiredProperties() throws IOException {
+    final ObjectMapper mapper = ObjectMapperTool.getMapper();
+
+    final JsonObject servicePointJson = new JsonObject();
+
+    servicePointJson.put("name", "Collection Point A");
+
+    final ServicePoint servicePoint = mapper.readValue(servicePointJson.encode(),
+      ServicePoint.class);
+
+    assertThat(servicePoint.getName(), is("Collection Point A"));
+    assertThat(servicePoint.getCode(), is(nullValue()));
+    assertThat(servicePoint.getDiscoveryDisplayName(), is(nullValue()));
   }
 }


### PR DESCRIPTION

*Purpose*
In order to stop new properties in service points from causing failures during login, additional properties could be temporarily allowed in the schema until there is a better approach.

*Limitations*
* There are a couple of simple unit tests to demonstrate this behaviour. They use the RAML Module Builder object mapper directly, which isn't ideal, if either the response class or the main code is changed these tests could provide false results. 

It might be possible to use the response class (and the convertToPojo method) but I didn't have time to investigate this due to the urgency of the change.

In future it could be preferable to extract the part of mod-users-bl which uses that and test that aspect instead, which would be more robust to implementation changes. 

*Other Information*
See https://issues.folio.org/browse/MODUSERBL-67