### PR TITLE
MODUSERBL-66 Reset password by link does not work

### DIFF
--- a/src/main/java/org/folio/rest/impl/BLUsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/BLUsersAPI.java
@@ -12,6 +12,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.ConfigurationsClient;
@@ -765,7 +766,7 @@ public class BLUsersAPI implements BlUsers {
       String userUrl = "/users?query=username=" + entity.getUsername();
       //run login
       try {
-        Map<String, String> headers = new HashMap<>(okapiHeaders);
+        Map<String, String> headers = new CaseInsensitiveMap<>(okapiHeaders);
         Optional.ofNullable(userAgent)
           .ifPresent(header -> headers.put(HttpHeaders.USER_AGENT, header));
         Optional.ofNullable(xForwardedFor)
@@ -1218,7 +1219,7 @@ public class BLUsersAPI implements BlUsers {
           } else {
             Errors errors = h.result().mapTo(Errors.class);
             if (errors.getTotalRecords() == 0) {
-              Map<String, String> requestHeaders = new HashMap<>(okapiHeaders);
+              Map<String, String> requestHeaders = new CaseInsensitiveMap<>(okapiHeaders);
               Optional.ofNullable(userAgent)
                 .ifPresent(header -> requestHeaders.put(HttpHeaders.USER_AGENT, header));
               Optional.ofNullable(xForwardedFor)
@@ -1272,7 +1273,7 @@ public class BLUsersAPI implements BlUsers {
                                             Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler,
                                             Context vertxContext) {
     JsonObject request = JsonObject.mapFrom(entity);
-    Map<String, String> requestHeaders = new HashMap<>(okapiHeaders);
+    Map<String, String> requestHeaders = new CaseInsensitiveMap<>(okapiHeaders);
     Optional.ofNullable(userAgent)
       .ifPresent(header -> requestHeaders.put(HttpHeaders.USER_AGENT, header));
     Optional.ofNullable(xForwardedFor)

--- a/src/test/java/org/folio/rest/HeadersForwardingTest.java
+++ b/src/test/java/org/folio/rest/HeadersForwardingTest.java
@@ -2,6 +2,7 @@ package org.folio.rest;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
@@ -27,23 +28,26 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import javax.ws.rs.core.HttpHeaders;
 import java.sql.Date;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.UUID;
 
+import static javax.ws.rs.core.HttpHeaders.USER_AGENT;
 import static junit.framework.TestCase.assertTrue;
 
 @RunWith(VertxUnitRunner.class)
 public class HeadersForwardingTest {
 
   private static final String TENANT = "test";
-  private static final String TOKEN = UUID.randomUUID().toString();
+  private static final String TOKEN = "access_token";
   private static final String USERNAME = "maxi";
   private static final String USER_ID = "0bb4f26d-e073-4f93-afbc-dcc24fd88810";
   private static final String RESET_PASSWORD_ACTION_ID = "0bb4f26d-e073-4f93-afbc-dcc24fd88810";
   private static final String IP = "216.3.128.12";
+
+  private static final String URL_AUT_RESET_PASSWORD = "/authn/reset-password";
+  private static final String URL_AUTH_UPDATE = "/authn/update";
+  private static final String URL_AUTH_LOGIN = "/authn/login";
 
   private RequestSpecification spec;
 
@@ -91,7 +95,7 @@ public class HeadersForwardingTest {
     );
 
     WireMock.stubFor(
-      WireMock.post("/authn/login")
+      WireMock.post(URL_AUTH_LOGIN)
         .willReturn(WireMock.okJson(JsonObject.mapFrom(credentials).encode()).withStatus(201))
     );
 
@@ -121,12 +125,6 @@ public class HeadersForwardingTest {
       .then()
       .statusCode(201);
 
-    WireMock.verify(
-      WireMock.postRequestedFor(WireMock.urlEqualTo("/authn/login"))
-        .withHeader(HttpHeaders.USER_AGENT, WireMock.matching(".+"))
-        .withHeader(BLUsersAPI.X_FORWARDED_FOR_HEADER, WireMock.equalTo(IP))
-    );
-
     WireMock.getAllServeEvents().stream()
       .map(ServeEvent::getRequest)
       .forEach(this::verifyHeaders);
@@ -141,7 +139,7 @@ public class HeadersForwardingTest {
     );
 
     WireMock.stubFor(
-      WireMock.post("/authn/update")
+      WireMock.post(URL_AUTH_UPDATE)
         .willReturn(WireMock.noContent())
     );
 
@@ -160,12 +158,6 @@ public class HeadersForwardingTest {
       .post("/bl-users/settings/myprofile/password")
       .then()
       .statusCode(204);
-
-    WireMock.verify(
-      WireMock.postRequestedFor(WireMock.urlEqualTo("/authn/update"))
-        .withHeader(HttpHeaders.USER_AGENT, WireMock.matching(".+"))
-        .withHeader(BLUsersAPI.X_FORWARDED_FOR_HEADER, WireMock.equalTo(IP))
-    );
 
     WireMock.getAllServeEvents().stream()
       .map(ServeEvent::getRequest)
@@ -196,7 +188,7 @@ public class HeadersForwardingTest {
 
     JsonObject isNewPassword = new JsonObject().put("isNewPassword", false);
     WireMock.stubFor(
-      WireMock.post("/authn/reset-password")
+      WireMock.post(URL_AUT_RESET_PASSWORD)
         .willReturn(WireMock.okJson(isNewPassword.encode()).withStatus(201))
     );
 
@@ -220,20 +212,27 @@ public class HeadersForwardingTest {
       .then()
       .statusCode(204);
 
-    WireMock.verify(
-      WireMock.postRequestedFor(WireMock.urlEqualTo("/authn/reset-password"))
-        .withHeader(HttpHeaders.USER_AGENT, WireMock.matching(".+"))
-        .withHeader(BLUsersAPI.X_FORWARDED_FOR_HEADER, WireMock.equalTo(IP))
-    );
-
     WireMock.getAllServeEvents().stream()
       .map(ServeEvent::getRequest)
       .forEach(this::verifyHeaders);
   }
 
   private void verifyHeaders(LoggedRequest request) {
-    com.github.tomakehurst.wiremock.http.HttpHeaders headers = request.getHeaders();
+    HttpHeaders headers = request.getHeaders();
+
+    String url = request.getUrl();
+    if (isContainsSpecifiedUrls(url)) {
+      assertTrue(headers.getHeader(BLUsersAPI.X_FORWARDED_FOR_HEADER).containsValue(IP));
+      assertTrue(headers.getHeader(USER_AGENT).hasValueMatching(WireMock.matching(".+")));
+    }
+
     assertTrue(headers.getHeader(RestVerticle.OKAPI_HEADER_TENANT).containsValue(TENANT));
     assertTrue(headers.getHeader(RestVerticle.OKAPI_HEADER_TOKEN).containsValue(TOKEN));
+  }
+
+  private boolean isContainsSpecifiedUrls(String url) {
+    return url.contains(URL_AUT_RESET_PASSWORD)
+      || url.contains(URL_AUTH_UPDATE)
+      || url.contains(URL_AUTH_LOGIN);
   }
 }


### PR DESCRIPTION
Reset password by link does not work after latest changes to mod-users-bl (security logging).
Reason: okapi headers (token, tenant, etc.) are not forwarded in requests to other modules.

[MODUSERBL-66](https://issues.folio.org/browse/MODUSERBL-66)