### PR TITLE
FOLIO-2003 initial module metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,15 @@ Example:
 
 Other [modules](https://dev.folio.org/source-code/#server-side).
 
+Other FOLIO Developer documentation is at [dev.folio.org](https://dev.folio.org/)
+
+### Issue tracker
+
 See project [MODUSERBL](https://issues.folio.org/browse/MODUSERBL)
 at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker/).
 
-Other FOLIO Developer documentation is at [dev.folio.org](https://dev.folio.org/)
+### ModuleDescriptor
+
+See the built `target/ModuleDescriptor.json` for the interfaces that this module
+requires and provides, the permissions, and the additional module metadata.
+

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -265,6 +265,10 @@
       "visible" : false
     }
   ],
+  "metadata": {
+    "containerMemory": "512",
+    "databaseConnection": "false"
+  },
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerArgs": {


### PR DESCRIPTION
Declare additional module metadata in ModuleDescriptor: containerMemory, databaseConnection

[FOLIO-2003](https://issues.folio.org/browse/FOLIO-2003)
