### PR TITLE
FOLIO-2003 Use containerMemory as for folio-ansible

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -266,7 +266,7 @@
     }
   ],
   "metadata": {
-    "containerMemory": "512",
+    "containerMemory": "256",
     "databaseConnection": "false"
   },
   "launchDescriptor": {


### PR DESCRIPTION
Align the value with that used in folio-ansible for reference environments.