### PR TITLE
Raising the interface version related to mod-login API breaking change

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -186,7 +186,7 @@
     },
     {
       "id" : "login",
-      "version" : "5.0"
+      "version" : "6.0"
     },
     {
       "id" : "service-points",

--- a/ramls/mod-users-bl.raml
+++ b/ramls/mod-users-bl.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0
 title: Mod-Users BL
+version: v5.0
 baseUri: http://github.com/org/folio/mod-users-bl
 
 documentation:


### PR DESCRIPTION
Changes in the version of the mod-login https://github.com/folio-org/mod-login/pull/64 affect changes in the modules: 

-  'edge-oai-pmh',
-  'edge-orders',
-  'edge-patron',
-  'edge-rtac',
-  'ui-users',
-  'mod-users-bl'
-  'edge-sip2'
-  'mod-login'