### PR TITLE
MODUSERBL-75: Update raml-util submodule

### DIFF
--- a/ramls/mod-users-bl.raml
+++ b/ramls/mod-users-bl.raml
@@ -18,7 +18,7 @@ types:
   proxyfor.json: !include proxyfor.json
   identifier: !include identifier.json
   errors: !include raml-util/schemas/errors.schema
-  updateCredentials: !include raml-util/schemas/mod-login/updateCredentials.json
+  updateCredentials: !include updateCredentials.json
   generateLinkRequest: !include generateLinkRequest.json
   generateLinkResponse: !include generateLinkResponse.json
   configurations: !include configurations.json

--- a/ramls/updateCredentials.json
+++ b/ramls/updateCredentials.json
@@ -1,0 +1,23 @@
+{
+  "title": "Update Credentials Schema",
+  "type": "object",
+  "description": "An entity that describes the necessary data to update a user password",
+  "properties": {
+    "username": {
+      "description": "username",
+      "type": "string"
+    },
+    "userId": {
+      "description": "Unique user id",
+      "type": "string"
+    },
+    "password": {
+      "description": "The current password of the user who will be replaced by the new one",
+      "type": "string"
+    },
+    "newPassword" : {
+      "description": "New user password",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
making metadata.createdByUserId optional

Make a copy https://github.com/folio-org/mod-login/blob/master/ramls/updateCredentials.json
as https://github.com/folio-org/raml/commit/b2209740e798e9b73e3dfa13f48e089c657ff4cc
removed the file from the raml-util submodule.