### PR TITLE
[MODUSERBL-78] Implementing token support `link expiration time`

### DIFF
--- a/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
+++ b/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -40,9 +41,11 @@ public class PasswordResetLinkServiceImpl implements PasswordResetLinkService {
   private static final String FOLIO_HOST_CONFIG_KEY = "FOLIO_HOST";
   private static final String UI_PATH_CONFIG_KEY = "RESET_PASSWORD_UI_PATH";
   private static final String LINK_EXPIRATION_TIME_CONFIG_KEY = "RESET_PASSWORD_LINK_EXPIRATION_TIME";
+  private static final String LINK_EXPIRATION_UNIT_OF_TIME_CONFIG_KEY = "RESET_PASSWORD_LINK_EXPIRATION_UNIT_OF_TIME";
   private static final Set<String> GENERATE_LINK_REQUIRED_CONFIGURATION = Collections.emptySet();
   private static final String LINK_EXPIRATION_TIME_DEFAULT = "86400000";
   private static final String FOLIO_HOST_DEFAULT = "http://localhost:3000";
+  private static final String INK_EXPIRATION_UNIT_OF_TIME_DEFAULT = "hours";
 
   private static final String CREATE_PASSWORD_EVENT_CONFIG_NAME = "CREATE_PASSWORD_EVENT";//NOSONAR
   private static final String RESET_PASSWORD_EVENT_CONFIG_NAME = "RESET_PASSWORD_EVENT";//NOSONAR
@@ -129,6 +132,11 @@ public class PasswordResetLinkServiceImpl implements PasswordResetLinkService {
         String generatedLink = linkHost + linkPath + '/' + token;
         linkHolder.value = generatedLink;
 
+        long expirationTimeFromConfig = Long.parseLong(
+          configMapHolder.value.getOrDefault(LINK_EXPIRATION_TIME_CONFIG_KEY, LINK_EXPIRATION_TIME_DEFAULT));
+        String expirationUnitOfTimeFromConfig = configMapHolder.value.getOrDefault(
+          LINK_EXPIRATION_UNIT_OF_TIME_CONFIG_KEY, INK_EXPIRATION_UNIT_OF_TIME_DEFAULT);
+
         String eventConfigName = passwordExistsHolder.value ? RESET_PASSWORD_EVENT_CONFIG_NAME : CREATE_PASSWORD_EVENT_CONFIG_NAME;
         Notification notification = new Notification()
           .withEventConfigName(eventConfigName)
@@ -136,7 +144,9 @@ public class PasswordResetLinkServiceImpl implements PasswordResetLinkService {
           .withContext(
             new Context()
               .withAdditionalProperty("user", JsonObject.mapFrom(userHolder.value))
-              .withAdditionalProperty("link", generatedLink))
+              .withAdditionalProperty("link", generatedLink)
+              .withAdditionalProperty("expirationTime", TimeUnit.MILLISECONDS.toHours(expirationTimeFromConfig))
+              .withAdditionalProperty("expirationUnitOfTime", expirationUnitOfTimeFromConfig))
           .withText(StringUtils.EMPTY)
           .withLang(DEFAULT_NOTIFICATION_LANG);
         return notificationClient.sendNotification(notification, connectionParams);

--- a/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
+++ b/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
@@ -171,7 +171,7 @@ public class PasswordResetLinkServiceImpl implements PasswordResetLinkService {
         return TimeUnit.DAYS.toMillis(expirationTime);
       case "WEEKS":
         return TimeUnit.DAYS.toMillis(expirationTime) * 7;
-      default: throw new IllegalStateException("Can't convert date to milliseconds");
+      default: throw new IllegalStateException("Can't convert time period to milliseconds");
     }
   }
 

--- a/src/test/java/org/folio/rest/GeneratePasswordRestLinkTest.java
+++ b/src/test/java/org/folio/rest/GeneratePasswordRestLinkTest.java
@@ -50,7 +50,7 @@ public class GeneratePasswordRestLinkTest {
   private static final String FOLIO_HOST_CONFIG_KEY = "FOLIO_HOST";
   private static final String CREATE_PASSWORD_EVENT_CONFIG_ID = "CREATE_PASSWORD_EVENT";
   private static final String RESET_PASSWORD_EVENT_CONFIG_ID = "RESET_PASSWORD_EVENT";
-  private static final long EXPIRATION_TIME = 86400000;
+  private static final String EXPIRATION_TIME = "24";
   private static final String EXPIRATION_UNIT_OF_TIME = "hours";
 
   private static final String MOCK_FOLIO_UI_HOST = "http://localhost:3000";
@@ -135,7 +135,7 @@ public class GeneratePasswordRestLinkTest {
         new Context()
           .withAdditionalProperty("user", mockUser)
           .withAdditionalProperty("link", expectedLink)
-          .withAdditionalProperty("expirationTime", TimeUnit.MILLISECONDS.toHours(EXPIRATION_TIME))
+          .withAdditionalProperty("expirationTime", EXPIRATION_TIME)
           .withAdditionalProperty("expirationUnitOfTime", EXPIRATION_UNIT_OF_TIME))
       .withRecipientId(mockUser.getId());
     WireMock.verify(WireMock.postRequestedFor(WireMock.urlMatching(NOTIFY_PATH))
@@ -182,7 +182,7 @@ public class GeneratePasswordRestLinkTest {
         new Context()
           .withAdditionalProperty("user", mockUser)
           .withAdditionalProperty("link", expectedLink)
-          .withAdditionalProperty("expirationTime", TimeUnit.MILLISECONDS.toHours(EXPIRATION_TIME))
+          .withAdditionalProperty("expirationTime", EXPIRATION_TIME)
           .withAdditionalProperty("expirationUnitOfTime", EXPIRATION_UNIT_OF_TIME))
       .withLang("en")
       .withRecipientId(mockUser.getId())

--- a/src/test/java/org/folio/rest/GeneratePasswordRestLinkTest.java
+++ b/src/test/java/org/folio/rest/GeneratePasswordRestLinkTest.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @RunWith(VertxUnitRunner.class)
@@ -49,7 +50,8 @@ public class GeneratePasswordRestLinkTest {
   private static final String FOLIO_HOST_CONFIG_KEY = "FOLIO_HOST";
   private static final String CREATE_PASSWORD_EVENT_CONFIG_ID = "CREATE_PASSWORD_EVENT";
   private static final String RESET_PASSWORD_EVENT_CONFIG_ID = "RESET_PASSWORD_EVENT";
-
+  private static final long EXPIRATION_TIME = 86400000;
+  private static final String EXPIRATION_UNIT_OF_TIME = "hours";
 
   private static final String MOCK_FOLIO_UI_HOST = "http://localhost:3000";
   private static final String DEFAULT_UI_URL = "/reset-password";
@@ -132,7 +134,9 @@ public class GeneratePasswordRestLinkTest {
       .withContext(
         new Context()
           .withAdditionalProperty("user", mockUser)
-          .withAdditionalProperty("link", expectedLink))
+          .withAdditionalProperty("link", expectedLink)
+          .withAdditionalProperty("expirationTime", TimeUnit.MILLISECONDS.toHours(EXPIRATION_TIME))
+          .withAdditionalProperty("expirationUnitOfTime", EXPIRATION_UNIT_OF_TIME))
       .withRecipientId(mockUser.getId());
     WireMock.verify(WireMock.postRequestedFor(WireMock.urlMatching(NOTIFY_PATH))
       .withRequestBody(WireMock.equalToJson(toJson(expectedNotification), true, true)));
@@ -177,7 +181,9 @@ public class GeneratePasswordRestLinkTest {
       .withContext(
         new Context()
           .withAdditionalProperty("user", mockUser)
-          .withAdditionalProperty("link", expectedLink))
+          .withAdditionalProperty("link", expectedLink)
+          .withAdditionalProperty("expirationTime", TimeUnit.MILLISECONDS.toHours(EXPIRATION_TIME))
+          .withAdditionalProperty("expirationUnitOfTime", EXPIRATION_UNIT_OF_TIME))
       .withLang("en")
       .withRecipientId(mockUser.getId())
       .withText(StringUtils.EMPTY);


### PR DESCRIPTION
Fixes [MODUSERBL-78](https://issues.folio.org/browse/MODUSERBL-78)

## Purpose
Currently, when we send reset password email to user, we have hard code `24 hours` in template.

## Approach
-add two configs for comfortable and flexible using
-change and add tests
-create logic for checking minutes/days/hours/weeks