### PR TITLE
[MODUSERBL-78] Implementing token support `link expiration time` in the template

### DIFF
--- a/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
+++ b/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -40,9 +41,11 @@ public class PasswordResetLinkServiceImpl implements PasswordResetLinkService {
   private static final String FOLIO_HOST_CONFIG_KEY = "FOLIO_HOST";
   private static final String UI_PATH_CONFIG_KEY = "RESET_PASSWORD_UI_PATH";
   private static final String LINK_EXPIRATION_TIME_CONFIG_KEY = "RESET_PASSWORD_LINK_EXPIRATION_TIME";
+  private static final String LINK_EXPIRATION_UNIT_OF_TIME_CONFIG_KEY = "RESET_PASSWORD_LINK_EXPIRATION_UNIT_OF_TIME";
   private static final Set<String> GENERATE_LINK_REQUIRED_CONFIGURATION = Collections.emptySet();
   private static final String LINK_EXPIRATION_TIME_DEFAULT = "86400000";
   private static final String FOLIO_HOST_DEFAULT = "http://localhost:3000";
+  private static final String INK_EXPIRATION_UNIT_OF_TIME_DEFAULT = "hours";
 
   private static final String CREATE_PASSWORD_EVENT_CONFIG_NAME = "CREATE_PASSWORD_EVENT";//NOSONAR
   private static final String RESET_PASSWORD_EVENT_CONFIG_NAME = "RESET_PASSWORD_EVENT";//NOSONAR
@@ -129,6 +132,11 @@ public class PasswordResetLinkServiceImpl implements PasswordResetLinkService {
         String generatedLink = linkHost + linkPath + '/' + token;
         linkHolder.value = generatedLink;
 
+        long expirationTimeFromConfig = Long.parseLong(
+          configMapHolder.value.getOrDefault(LINK_EXPIRATION_TIME_CONFIG_KEY, LINK_EXPIRATION_TIME_DEFAULT));
+        String expirationUnitOfTimeFromConfig = configMapHolder.value.getOrDefault(
+          LINK_EXPIRATION_UNIT_OF_TIME_CONFIG_KEY, INK_EXPIRATION_UNIT_OF_TIME_DEFAULT);
+
         String eventConfigName = passwordExistsHolder.value ? RESET_PASSWORD_EVENT_CONFIG_NAME : CREATE_PASSWORD_EVENT_CONFIG_NAME;
         Notification notification = new Notification()
           .withEventConfigName(eventConfigName)
@@ -136,7 +144,9 @@ public class PasswordResetLinkServiceImpl implements PasswordResetLinkService {
           .withContext(
             new Context()
               .withAdditionalProperty("user", JsonObject.mapFrom(userHolder.value))
-              .withAdditionalProperty("link", generatedLink))
+              .withAdditionalProperty("link", generatedLink)
+              .withAdditionalProperty("expirationTime", TimeUnit.MILLISECONDS.toHours(expirationTimeFromConfig))
+              .withAdditionalProperty("expirationUnitOfTime", expirationUnitOfTimeFromConfig))
           .withText(StringUtils.EMPTY)
           .withLang(DEFAULT_NOTIFICATION_LANG);
         return notificationClient.sendNotification(notification, connectionParams);

--- a/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
+++ b/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
@@ -171,7 +171,7 @@ public class PasswordResetLinkServiceImpl implements PasswordResetLinkService {
         return TimeUnit.DAYS.toMillis(expirationTime);
       case "WEEKS":
         return TimeUnit.DAYS.toMillis(expirationTime) * 7;
-      default: throw new IllegalStateException("Can't convert date to milliseconds");
+      default: throw new IllegalStateException("Can't convert time period to milliseconds");
     }
   }
 

--- a/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
+++ b/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
@@ -165,7 +165,9 @@ public class PasswordResetLinkServiceImpl implements PasswordResetLinkService {
     try {
       expirationTime = Long.parseLong(expirationTimeDefault);
     } catch (NumberFormatException e) {
-      expirationTime = Long.parseLong(LINK_EXPIRATION_TIME_DEFAULT);
+      String message = "Can't convert time period to milliseconds";
+      UnprocessableEntityMessage entityMessage = new UnprocessableEntityMessage(LINK_INVALID_STATUS_CODE, message);
+      throw new UnprocessableEntityException(Collections.singletonList(entityMessage));
     }
     switch (expirationUnitOfTime) {
       case "MINUTES":

--- a/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
+++ b/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
@@ -161,7 +161,12 @@ public class PasswordResetLinkServiceImpl implements PasswordResetLinkService {
   }
 
   private long convertDateToMilliseconds(String expirationTimeDefault, String expirationUnitOfTime) {
-    long expirationTime = Long.parseLong(expirationTimeDefault);
+    long expirationTime;
+    try {
+      expirationTime = Long.parseLong(expirationTimeDefault);
+    } catch (NumberFormatException e) {
+      expirationTime = Long.parseLong(LINK_EXPIRATION_TIME_DEFAULT);
+    }
     switch (expirationUnitOfTime) {
       case "MINUTES":
         return TimeUnit.MINUTES.toMillis(expirationTime);
@@ -171,7 +176,10 @@ public class PasswordResetLinkServiceImpl implements PasswordResetLinkService {
         return TimeUnit.DAYS.toMillis(expirationTime);
       case "WEEKS":
         return TimeUnit.DAYS.toMillis(expirationTime) * 7;
-      default: throw new IllegalStateException("Can't convert time period to milliseconds");
+      default:
+        String message = "Can't convert time period to milliseconds";
+        UnprocessableEntityMessage entityMessage = new UnprocessableEntityMessage(LINK_INVALID_STATUS_CODE, message);
+        throw new UnprocessableEntityException(Collections.singletonList(entityMessage));
     }
   }
 

--- a/src/test/java/org/folio/rest/GeneratePasswordRestLinkTest.java
+++ b/src/test/java/org/folio/rest/GeneratePasswordRestLinkTest.java
@@ -64,7 +64,6 @@ public class GeneratePasswordRestLinkTest {
   private static final String EXPIRATION_UNIT_OF_TIME_INCORRECT = "test";
   private static final String RESET_PASSWORD_LINK_EXPIRATION_UNIT_OF_TIME = "RESET_PASSWORD_LINK_EXPIRATION_UNIT_OF_TIME";
   private static final String RESET_PASSWORD_LINK_EXPIRATION_TIME = "RESET_PASSWORD_LINK_EXPIRATION_TIME";
-
   private static final String MOCK_FOLIO_UI_HOST = "http://localhost:3000";
   private static final String DEFAULT_UI_URL = "/reset-password";
   private static final String MOCK_TOKEN = "mockToken";
@@ -216,6 +215,8 @@ public class GeneratePasswordRestLinkTest {
     String expirationTime, String expirationTimeOfUnit) {
     Map<String, String> configToMock = new HashMap<>();
     configToMock.put(FOLIO_HOST_CONFIG_KEY, MOCK_FOLIO_UI_HOST);
+    configToMock.put(RESET_PASSWORD_LINK_EXPIRATION_TIME, expirationTime);
+    configToMock.put(RESET_PASSWORD_LINK_EXPIRATION_UNIT_OF_TIME, expirationTimeOfUnit);
     User mockUser = new User()
       .withId(UUID.randomUUID().toString())
       .withUsername(MOCK_USERNAME);

--- a/src/test/java/org/folio/rest/GeneratePasswordRestLinkTest.java
+++ b/src/test/java/org/folio/rest/GeneratePasswordRestLinkTest.java
@@ -50,7 +50,7 @@ public class GeneratePasswordRestLinkTest {
   private static final String FOLIO_HOST_CONFIG_KEY = "FOLIO_HOST";
   private static final String CREATE_PASSWORD_EVENT_CONFIG_ID = "CREATE_PASSWORD_EVENT";
   private static final String RESET_PASSWORD_EVENT_CONFIG_ID = "RESET_PASSWORD_EVENT";
-  private static final long EXPIRATION_TIME = 86400000;
+  private static final String EXPIRATION_TIME = "24";
   private static final String EXPIRATION_UNIT_OF_TIME = "hours";
 
   private static final String MOCK_FOLIO_UI_HOST = "http://localhost:3000";
@@ -135,7 +135,7 @@ public class GeneratePasswordRestLinkTest {
         new Context()
           .withAdditionalProperty("user", mockUser)
           .withAdditionalProperty("link", expectedLink)
-          .withAdditionalProperty("expirationTime", TimeUnit.MILLISECONDS.toHours(EXPIRATION_TIME))
+          .withAdditionalProperty("expirationTime", EXPIRATION_TIME)
           .withAdditionalProperty("expirationUnitOfTime", EXPIRATION_UNIT_OF_TIME))
       .withRecipientId(mockUser.getId());
     WireMock.verify(WireMock.postRequestedFor(WireMock.urlMatching(NOTIFY_PATH))
@@ -182,7 +182,7 @@ public class GeneratePasswordRestLinkTest {
         new Context()
           .withAdditionalProperty("user", mockUser)
           .withAdditionalProperty("link", expectedLink)
-          .withAdditionalProperty("expirationTime", TimeUnit.MILLISECONDS.toHours(EXPIRATION_TIME))
+          .withAdditionalProperty("expirationTime", EXPIRATION_TIME)
           .withAdditionalProperty("expirationUnitOfTime", EXPIRATION_UNIT_OF_TIME))
       .withLang("en")
       .withRecipientId(mockUser.getId())

--- a/src/test/java/org/folio/rest/GeneratePasswordRestLinkTest.java
+++ b/src/test/java/org/folio/rest/GeneratePasswordRestLinkTest.java
@@ -1,7 +1,8 @@
 package org.folio.rest;
-import static org.junit.Assert.*;
-
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
@@ -17,6 +18,11 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.ws.rs.core.MediaType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
@@ -28,19 +34,11 @@ import org.folio.rest.jaxrs.model.Notification;
 import org.folio.rest.jaxrs.model.PasswordResetAction;
 import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.tools.utils.NetworkUtils;
-import org.hamcrest.Matchers;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 @RunWith(VertxUnitRunner.class)
 public class GeneratePasswordRestLinkTest {
@@ -172,17 +170,21 @@ public class GeneratePasswordRestLinkTest {
   }
 
   @Test
-  public void shouldGenerateAndSendPasswordNotificationWhenExpirationTimeIsDefault() {
-    generateAndSendResetPasswordNotificationWhenPasswordExistsWith("TEST",
-      EXPIRATION_UNIT_OF_TIME_MINUTES);
+  public void shouldGenerateAndSendPasswordNotificationWhenExpirationTimeIsIncorrect() {
+    shouldHandleExceptionWhenConvertTime("TEST", EXPIRATION_UNIT_OF_TIME_MINUTES);
   }
 
   @Test
-  public void shouldGenerateAndSendResetPasswordNotificationWhenPasswordExistsWithIncorrectTime() {
+  public void shouldGenerateAndSendPasswordNotificationWhenExpirationOfUnitTimeIsIncorrect() {
+    shouldHandleExceptionWhenConvertTime(EXPIRATION_TIME_WEEKS, EXPIRATION_UNIT_OF_TIME_INCORRECT);
+  }
+
+  public void shouldHandleExceptionWhenConvertTime(
+    String expirationTime, String expirationTimeOfUnit){
     Map<String, String> configToMock = new HashMap<>();
     configToMock.put(FOLIO_HOST_CONFIG_KEY, MOCK_FOLIO_UI_HOST);
-    configToMock.put(RESET_PASSWORD_LINK_EXPIRATION_TIME, EXPIRATION_TIME_WEEKS);
-    configToMock.put(RESET_PASSWORD_LINK_EXPIRATION_UNIT_OF_TIME, EXPIRATION_UNIT_OF_TIME_INCORRECT);
+    configToMock.put(RESET_PASSWORD_LINK_EXPIRATION_TIME, expirationTime);
+    configToMock.put(RESET_PASSWORD_LINK_EXPIRATION_UNIT_OF_TIME, expirationTimeOfUnit);
     User mockUser = new User()
       .withId(UUID.randomUUID().toString())
       .withUsername(MOCK_USERNAME);

--- a/src/test/java/org/folio/rest/GeneratePasswordRestLinkTest.java
+++ b/src/test/java/org/folio/rest/GeneratePasswordRestLinkTest.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @RunWith(VertxUnitRunner.class)
@@ -49,7 +50,8 @@ public class GeneratePasswordRestLinkTest {
   private static final String FOLIO_HOST_CONFIG_KEY = "FOLIO_HOST";
   private static final String CREATE_PASSWORD_EVENT_CONFIG_ID = "CREATE_PASSWORD_EVENT";
   private static final String RESET_PASSWORD_EVENT_CONFIG_ID = "RESET_PASSWORD_EVENT";
-
+  private static final long EXPIRATION_TIME = 86400000;
+  private static final String EXPIRATION_UNIT_OF_TIME = "hours";
 
   private static final String MOCK_FOLIO_UI_HOST = "http://localhost:3000";
   private static final String DEFAULT_UI_URL = "/reset-password";
@@ -132,7 +134,9 @@ public class GeneratePasswordRestLinkTest {
       .withContext(
         new Context()
           .withAdditionalProperty("user", mockUser)
-          .withAdditionalProperty("link", expectedLink))
+          .withAdditionalProperty("link", expectedLink)
+          .withAdditionalProperty("expirationTime", TimeUnit.MILLISECONDS.toHours(EXPIRATION_TIME))
+          .withAdditionalProperty("expirationUnitOfTime", EXPIRATION_UNIT_OF_TIME))
       .withRecipientId(mockUser.getId());
     WireMock.verify(WireMock.postRequestedFor(WireMock.urlMatching(NOTIFY_PATH))
       .withRequestBody(WireMock.equalToJson(toJson(expectedNotification), true, true)));
@@ -177,7 +181,9 @@ public class GeneratePasswordRestLinkTest {
       .withContext(
         new Context()
           .withAdditionalProperty("user", mockUser)
-          .withAdditionalProperty("link", expectedLink))
+          .withAdditionalProperty("link", expectedLink)
+          .withAdditionalProperty("expirationTime", TimeUnit.MILLISECONDS.toHours(EXPIRATION_TIME))
+          .withAdditionalProperty("expirationUnitOfTime", EXPIRATION_UNIT_OF_TIME))
       .withLang("en")
       .withRecipientId(mockUser.getId())
       .withText(StringUtils.EMPTY);


### PR DESCRIPTION
Fixes [MODUSERBL-78](https://issues.folio.org/browse/MODUSERBL-78)

## Purpose
Currently, when we send reset password email to user, we have hard code `24 hours` in template.

## Approach
-create logic for checking time in minutes/hours/days/weeks
-add two tokens to context
-change and add tests