### PR TITLE
MODUSERBL-89 Allow additional properties in User

### DIFF
--- a/ramls/userdata.json
+++ b/ramls/userdata.json
@@ -164,7 +164,7 @@
       "$ref": "raml-util/schemas/tags.schema"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "id"
   ]


### PR DESCRIPTION
PR addresses the issue from [MODUSERBL-89](https://issues.folio.org/browse/MODUSERBL-89) 

If there is a difference between User schemas from mod-users and mod-users-bl then allow all unknown properties to be added into `additionalProperties`. Those unknown properties are not need by mod-users-bl to do the work. So they can be ignored and saving them in `additionalProperties` is a way to do it.

This should resolve any further cases when a new property defined for User in mod-users cannot be processed by mod-user-bl without explicit definition. 

Below is an example of how `customFields` deserealized in mod-users-bl w/o the fields being present in the schema:
![image](https://user-images.githubusercontent.com/42244720/82054361-81e2bc80-96c7-11ea-8090-36c8817ba1d7.png)
