### PR TITLE
MODUSERBL-97 Remove the ability to retrieve credentials (hash/salt)

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "users-bl",
-      "version": "5.0",
+      "version": "6.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -186,7 +186,7 @@
     },
     {
       "id" : "login",
-      "version" : "6.0"
+      "version" : "6.0 7.0"
     },
     {
       "id" : "service-points",

--- a/ramls/compositeUser.json
+++ b/ramls/compositeUser.json
@@ -18,11 +18,6 @@
       "description": "Permissions object",
       "$ref": "permissionUser.json"
     },
-    "credentials": {
-      "type": "object",
-      "description": "Credentials object",
-      "$ref": "credentials.json"
-    },
     "proxiesFor": {
       "type": "array",
       "description": "Proxies for, array",

--- a/ramls/mod-users-bl.raml
+++ b/ramls/mod-users-bl.raml
@@ -14,7 +14,6 @@ types:
   userdata.json: !include userdata.json
   usergroup.json: !include usergroup.json
   permissionUser.json: !include permissionUser.json
-  credentials.json: !include credentials.json
   proxyfor.json: !include proxyfor.json
   identifier: !include identifier.json
   errors: !include raml-util/schemas/errors.schema

--- a/src/main/java/org/folio/rest/impl/BLUsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/BLUsersAPI.java
@@ -81,6 +81,8 @@ import java.util.stream.Stream;
  * @author shale
  *
  */
+@SuppressWarnings("java:S1192")
+// String literals should not be duplicated ("/perms/users", and "userId")
 public class BLUsersAPI implements BlUsers {
 
   private static final String GROUPS_INCLUDE = "groups";
@@ -605,10 +607,8 @@ public class BLUsersAPI implements BlUsers {
           return;
         }
         Response groupResponse = null;
-        Response credsResponse = null;
         Response permsResponse = null;
         Response proxiesforResponse = null;
-        Response servicePointsUserResponse = null;
         CompletableFuture<Response> cf = completedLookup.get(GROUPS_INCLUDE);
         if(cf != null){
           groupResponse = cf.get();


### PR DESCRIPTION
Please see https://issues.folio.org/browse/MODUSERBL-97: Remove the ability to retrieve credentials (hash/salt)

Note, suppressed literal duplication Sonar warning to avoid introducing new changes that would trigger code coverage bomb. It needs to be released by tomorrow.