### PR TITLE
Added limit value to service point query

### DIFF
--- a/src/main/java/org/folio/rest/impl/BLUsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/BLUsersAPI.java
@@ -112,6 +112,8 @@ public class BLUsersAPI implements BlUsers {
   private static final String FORGOTTEN_PASSWORD_ERROR_KEY = "forgotten.password.found.multiple.users";//NOSONAR
   private static final String FORGOTTEN_PASSWORD_FOUND_INACTIVE = "forgotten.password.found.inactive";//NOSONAR
 
+  private static final String QUERY_LIMIT = "&limit=1000";
+
   private static final Pattern HOST_PORT_PATTERN = Pattern.compile("https?://([^:/]+)(?::?(\\d+)?)");
 
   private static final int DEFAULT_PORT = 9030;
@@ -349,7 +351,7 @@ public class BLUsersAPI implements BlUsers {
       }
       else if(include.get(i).equals(SERVICEPOINTS_INCLUDE)) {
         CompletableFuture<Response> servicePointsResponse = userIdResponse[0].thenCompose(
-          client.chainedRequest("/service-points-users?query=userId==" + userTemplate,
+          client.chainedRequest("/service-points-users?query=userId==" + userTemplate + QUERY_LIMIT,
               okapiHeaders, null, handlePreviousResponse(false, false, false,
               aRequestHasFailed, asyncResultHandler))
         );
@@ -778,7 +780,7 @@ public class BLUsersAPI implements BlUsers {
         }
         else if(include.get(i).equals(SERVICEPOINTS_INCLUDE)) {
           CompletableFuture<Response> servicePointsResponse = userResponse[0].thenCompose(
-            client.chainedRequest("/service-points-users?query=userId=={users[0].id}",
+            client.chainedRequest("/service-points-users?query=userId=={users[0].id}" + QUERY_LIMIT,
                 okapiHeaders, null, handlePreviousResponse(false, false, false,
                 aRequestHasFailed, asyncResultHandler))
           );
@@ -965,7 +967,7 @@ public class BLUsersAPI implements BlUsers {
         java.util.logging.Logger.getLogger(BLUsersAPI.class.getName()).log(Level.SEVERE, null, ex);
       }
       CompletableFuture<Response> expandSPUResponse = spuResponseFuture
-          .thenCompose(client.chainedRequest("/service-points?query="+ idQuery,
+          .thenCompose(client.chainedRequest("/service-points?query="+ idQuery + QUERY_LIMIT,
           okapiHeaders, true, null, handlePreviousResponse(false, false, false,
           aRequestHasFailed, asyncResultHandler)));
 

--- a/src/test/java/org/folio/rest/HeadersForwardingTest.java
+++ b/src/test/java/org/folio/rest/HeadersForwardingTest.java
@@ -58,6 +58,7 @@ public class HeadersForwardingTest {
   private static final String URL_AUT_RESET_PASSWORD = "/authn/reset-password";
   private static final String URL_AUTH_UPDATE = "/authn/update";
   private static final String URL_AUTH_LOGIN = "/authn/login";
+  private static final String QUERY_LIMIT = "&limit=1000";
 
   private RequestSpecification spec;
 
@@ -122,7 +123,7 @@ public class HeadersForwardingTest {
       .put("servicePointsUsers", new JsonArray());
 
     WireMock.stubFor(
-      WireMock.get("/service-points-users?query=userId==" + USER_ID)
+      WireMock.get("/service-points-users?query=userId==" + USER_ID + QUERY_LIMIT)
         .willReturn(WireMock.okJson(jsonObject.encode()).withStatus(201))
     );
 
@@ -182,7 +183,7 @@ public class HeadersForwardingTest {
       .put("servicePointsUsers", new JsonArray());
 
     WireMock.stubFor(
-      WireMock.get("/service-points-users?query=userId==" + USER_ID)
+      WireMock.get("/service-points-users?query=userId==" + USER_ID + QUERY_LIMIT)
         .willReturn(WireMock.okJson(jsonObject.encode()).withStatus(201))
     );
 


### PR DESCRIPTION
This pull request resolves [MODUSERBL-95](https://issues.folio.org/browse/MODUSERBL-95)

### Approach

The simple solution to this issue was to append a limit criteria to the query for service points. I investigated creating a test to show that more than 10 service points would be supplied, but since the data is retrieved from mod-inventory-storage, the test data for service points is mocked and testing the contents of mocked data seemed pointless. I would recommend a UI test to verify more than 10 service points can be displayed.

I was able to test these changes using the folio/testing vagrant and swapping out the modified module. I was able to confirm the fix was successful. 