### PR TITLE
MODUSERBL-101 Fix not recognize field "preferredFirstName"

### DIFF
--- a/ramls/userdata.json
+++ b/ramls/userdata.json
@@ -128,7 +128,7 @@
           "description": "Preferred contact type Id"
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": [
         "lastName"
       ]

--- a/ramls/userdata.json
+++ b/ramls/userdata.json
@@ -120,7 +120,7 @@
                 "description": "Is primary address"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": true
           }
         },
         "preferredContactTypeId": {


### PR DESCRIPTION
Resolves issue [MODUSERBL-101](https://issues.folio.org/browse/MODUSERBL-101)

## Approach
Set `"additionalProperties": true` in `personal` object that should allow any additional properties received from mod-users