### PR TITLE
MODUSERBL-109: Fix logging.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,11 +368,22 @@
                   <manifestEntries>
                     <Main-Class>org.folio.rest.RestLauncher</Main-Class>
                     <Main-Verticle>org.folio.rest.RestVerticle</Main-Verticle>
+                    <Multi-Release>true</Multi-Release>
                   </manifestEntries>
                 </transformer>
               </transformers>
               <artifactSet />
               <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
+              <filters>
+                <!-- this required to fix module logging -->
+                <!-- There are some errors in runtime and logging settings seems reset -->
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>**/Log4j2Plugins.dat</exclude>
+                  </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
https://issues.folio.org/browse/MODUSERBL-109 - Logging is broken for the module

### Changes
* Fix logging by adding a filter to maven shade plugin that removes log4j cache file.
* Add manifest entry to fix `WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.`

![image](https://user-images.githubusercontent.com/9094650/95463824-eb6aac80-0981-11eb-8508-58565fac2c29.png)
