### PR TITLE
MODTEMPENG-59 Update notification context to have dateTime

### DIFF
--- a/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
+++ b/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
@@ -269,12 +269,15 @@ public class PasswordResetLinkServiceImpl implements PasswordResetLinkService {
                                           Holder<String> userIdHolder,
                                           boolean isNewPassword) {
     Context context = new Context()
-      .withAdditionalProperty("user", userHolder.value)
-      .withAdditionalProperty("detailedDateTime", OffsetDateTime.now().toString());
+      .withAdditionalProperty("user", userHolder.value);
 
-    String eventConfigName = isNewPassword
-      ? PASSWORD_CREATED_EVENT_CONFIG_NAME
-      : PASSWORD_CHANGED_EVENT_CONFIG_NAME;
+    String eventConfigName;
+    if (isNewPassword) {
+      eventConfigName = PASSWORD_CREATED_EVENT_CONFIG_NAME;
+    } else {
+      eventConfigName = PASSWORD_CHANGED_EVENT_CONFIG_NAME;
+      context.withAdditionalProperty("detailedDateTime", OffsetDateTime.now().toString());
+    }
 
     return new Notification()
       .withRecipientId(userIdHolder.value)

--- a/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
+++ b/src/main/java/org/folio/service/PasswordResetLinkServiceImpl.java
@@ -23,6 +23,7 @@ import org.folio.service.password.UserPasswordService;
 
 import javax.xml.ws.Holder;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
@@ -268,7 +269,8 @@ public class PasswordResetLinkServiceImpl implements PasswordResetLinkService {
                                           Holder<String> userIdHolder,
                                           boolean isNewPassword) {
     Context context = new Context()
-      .withAdditionalProperty("user", userHolder.value);
+      .withAdditionalProperty("user", userHolder.value)
+      .withAdditionalProperty("detailedDateTime", OffsetDateTime.now().toString());
 
     String eventConfigName = isNewPassword
       ? PASSWORD_CREATED_EVENT_CONFIG_NAME


### PR DESCRIPTION
## Purpose
Send correct notification to mod-notify to have a valid date in the email notification.

## Approach
* Add dateTime to notification context