### PR TITLE
JUnit 4.13.1 fixing TemporaryFolder vulnerability (CVE-2020-15250)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The JUnit4 test rule TemporaryFolder contains a local information disclosure
vulnerability: TemporaryFolder on unix-like systems does not limit access to created files.

https://github.com/advisories/GHSA-269g-pwp5-87pp
https://nvd.nist.gov/vuln/detail/CVE-2020-15250

Changing to version 4.13.1 fixes this.