### PR TITLE
MODUSERBL-123: Log4j vulnerability verification and correction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 7.2.0 IN-PROGRESS
+
+* Upgrade to RMB to address log4j security vulverability (MODUSERBL-123)
+
 ## 7.1.0 2021-10-05
  
 * Optionally requires `feesfines 16.3 or 17.0`

--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <raml-module-builder.version>33.0.0</raml-module-builder.version>
+    <raml-module-builder.version>33.0.4</raml-module-builder.version>
     <mod-configuration-client.version>5.6.0</mod-configuration-client.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <vertx-version>4.1.0.CR1</vertx-version>


### PR DESCRIPTION
My understanding from reading the wiki on this issue is
that if a module uses RMB and does not have an explicit
log4j dependency declared, upgrading the RMB to a 
version that has the log4j fix in should solve the issue.
This module fits that description, so I have moved
the RMB version to 33.0.4, the closest compatible 
version that contains the fix.