### PR TITLE
Remove reference to login.item.get MODUSERBL-141

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -59,7 +59,6 @@
             "users.item.get",
             "users.collection.get",
             "perms.users.get",
-            "login.item.get",
             "inventory-storage.service-points-users.collection.get",
             "inventory-storage.service-points-users.item.get",
             "inventory-storage.service-points.collection.get",
@@ -74,7 +73,6 @@
             "users.item.get",
             "users.collection.get",
             "perms.users.get",
-            "login.item.get",
             "inventory-storage.service-points-users.collection.get",
             "inventory-storage.service-points-users.item.get",
             "inventory-storage.service-points.collection.get",
@@ -222,7 +220,7 @@
     },
     {
       "id" : "login",
-      "version" : "6.0 7.0"
+      "version" : "7.0"
     },
     {
       "id" : "service-points",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -220,7 +220,7 @@
     },
     {
       "id" : "login",
-      "version" : "7.0"
+      "version" : "6.0 7.0"
     },
     {
       "id" : "service-points",


### PR DESCRIPTION
This was removed in login interface 7.0.