### PR TITLE
MODUSERBL-80: Vert.x HttpClient objects are leaked

### DIFF
--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -7,6 +7,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.serviceproxy.ServiceBinder;
 import org.folio.rest.resource.interfaces.InitAPI;
+import org.folio.rest.util.HttpClientUtil;
 import org.folio.service.password.UserPasswordService;
 import org.folio.service.password.UserPasswordServiceImpl;
 
@@ -18,9 +19,10 @@ public class InitAPIs implements InitAPI {
 
   @Override
   public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> handler) {
+    var httpClient = HttpClientUtil.getInstance(vertx);
     new ServiceBinder(vertx)
       .setAddress(UserPasswordServiceImpl.USER_PASS_SERVICE_ADDRESS)
-      .register(UserPasswordService.class, UserPasswordService.create(vertx));
+      .register(UserPasswordService.class, UserPasswordService.create(httpClient));
     handler.handle(Future.succeededFuture(true));
   }
 }

--- a/src/main/java/org/folio/rest/util/HttpClientUtil.java
+++ b/src/main/java/org/folio/rest/util/HttpClientUtil.java
@@ -5,8 +5,12 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import org.folio.rest.RestVerticle;
 
-public class HttpClientUtil {
+public final class HttpClientUtil {
   private static final String KEY = "httpClient";
+
+  private HttpClientUtil() {
+    throw new UnsupportedOperationException("Cannot instantiate utility class");
+  }
 
   public static HttpClient getInstance(Vertx vertx) {
     var context = vertx.getOrCreateContext();

--- a/src/main/java/org/folio/rest/util/HttpClientUtil.java
+++ b/src/main/java/org/folio/rest/util/HttpClientUtil.java
@@ -1,0 +1,29 @@
+package org.folio.rest.util;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import org.folio.rest.RestVerticle;
+
+public class HttpClientUtil {
+  private static final String KEY = "httpClient";
+
+  public static HttpClient getInstance(Vertx vertx) {
+    var context = vertx.getOrCreateContext();
+    var httpClient = (HttpClient) context.getLocal(KEY);
+    if (httpClient == null) {
+      httpClient = initHttpClient(vertx);
+      context.putLocal(KEY, httpClient);
+    }
+    return httpClient;
+  }
+
+  private static HttpClient initHttpClient(Vertx vertx) {
+    int lookupTimeout = Integer
+      .parseInt(RestVerticle.MODULE_SPECIFIC_ARGS.getOrDefault("lookup.timeout", "1000"));
+    HttpClientOptions options = new HttpClientOptions();
+    options.setConnectTimeout(lookupTimeout);
+    options.setIdleTimeout(lookupTimeout);
+    return vertx.createHttpClient(options);
+  }
+}

--- a/src/main/java/org/folio/service/password/UserPasswordService.java
+++ b/src/main/java/org/folio/service/password/UserPasswordService.java
@@ -5,6 +5,7 @@ import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.JsonObject;
 
 
@@ -14,8 +15,8 @@ import io.vertx.core.json.JsonObject;
 @ProxyGen
 public interface UserPasswordService {
 
-  static UserPasswordService create(Vertx vertx) {
-    return new UserPasswordServiceImpl(vertx);
+  static UserPasswordService create(HttpClient httpClient) {
+    return new UserPasswordServiceImpl(httpClient);
   }
 
   /**

--- a/src/main/java/org/folio/service/password/UserPasswordServiceImpl.java
+++ b/src/main/java/org/folio/service/password/UserPasswordServiceImpl.java
@@ -4,15 +4,12 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
-import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.rest.RestVerticle;
 import org.folio.rest.impl.BLUsersAPI;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
@@ -30,27 +27,13 @@ public class UserPasswordServiceImpl implements UserPasswordService {
   private static final String VALIDATE_URL = "/password/validate";
   private static final String UPDATE_URL = "/authn/update";
 
-  // Timeout to wait for response
-  private int lookupTimeout = Integer
-    .parseInt(RestVerticle.MODULE_SPECIFIC_ARGS.getOrDefault("lookup.timeout", "1000"));
-
   // Http client to call programmatic rules as internal OKAPI endpoints
   private HttpClient httpClient;
 
   private static final Logger logger = LogManager.getLogger(UserPasswordServiceImpl.class);
 
-  private void initHttpClient(final Vertx vertx) {
-    HttpClientOptions options = new HttpClientOptions();
-    options.setConnectTimeout(lookupTimeout);
-    options.setIdleTimeout(lookupTimeout);
-    this.httpClient = vertx.createHttpClient(options);
-  }
-
-  public UserPasswordServiceImpl() {
-  }
-
-  public UserPasswordServiceImpl(final Vertx vertx) {
-    initHttpClient(vertx);
+  public UserPasswordServiceImpl(HttpClient httpClient) {
+    this.httpClient = httpClient;
   }
 
   @Override

--- a/src/test/java/org/folio/rest/util/HttpClientUtilTest.java
+++ b/src/test/java/org/folio/rest/util/HttpClientUtilTest.java
@@ -5,12 +5,18 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import io.vertx.core.Vertx;
+import org.folio.rest.testing.UtilityClassTester;
 import org.junit.Test;
 
 public class HttpClientUtilTest {
 
   @Test
-  public void test() {
+  public void utilityClass() {
+    UtilityClassTester.assertUtilityClass(HttpClientUtil.class);
+  }
+
+  @Test
+  public void getInstance() {
     var vertx = Vertx.vertx();
     var httpClient1 = HttpClientUtil.getInstance(vertx);
     var httpClient2 = HttpClientUtil.getInstance(vertx);

--- a/src/test/java/org/folio/rest/util/HttpClientUtilTest.java
+++ b/src/test/java/org/folio/rest/util/HttpClientUtilTest.java
@@ -1,0 +1,22 @@
+package org.folio.rest.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import io.vertx.core.Vertx;
+import org.junit.Test;
+
+public class HttpClientUtilTest {
+
+  @Test
+  public void test() {
+    var vertx = Vertx.vertx();
+    var httpClient1 = HttpClientUtil.getInstance(vertx);
+    var httpClient2 = HttpClientUtil.getInstance(vertx);
+    var httpClient3 = HttpClientUtil.getInstance(Vertx.vertx());
+    assertThat(httpClient1, is(httpClient2));
+    assertThat(httpClient1, is(not(httpClient3)));
+  }
+
+}


### PR DESCRIPTION
Reuse one HttpClient for all requests.

Note that `WebClient.wrap(client)` doesn't create a new client but reuses
the passed HttpClient.