### PR TITLE
Double memory allocation MODUSERBL-144

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -326,7 +326,7 @@
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 357913941,
+        "Memory": 715827882,
         "PortBindings": { "8081/tcp": [ { "HostPort": "%p" } ] }
       }
     },


### PR DESCRIPTION
Experiment to check if this could be a temporary resolution. Given that we don't know the cause of the recent failures on the hosted reference environments.

The new amount is arbitrary (I doubled it because it was a convenient calculation).