### PR TITLE
MODUSERBL-153: Leverage optional okapi dependencies

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -223,23 +223,7 @@
       "version" : "6.0 7.0"
     },
     {
-      "id" : "service-points",
-      "version" : "2.1 3.0"
-    },
-    {
-      "id" : "service-points-users",
-      "version" : "1.0"
-    },
-    {
-      "id": "password-validator",
-      "version": "1.0"
-    },
-    {
       "id": "authtoken",
-      "version": "2.0"
-    },
-    {
-      "id": "notify",
       "version": "2.0"
     },
     {
@@ -255,6 +239,22 @@
     {
       "id": "feesfines",
       "version": "16.3 17.0"
+    },
+    {
+      "id" : "service-points",
+      "version" : "2.1 3.0"
+    },
+    {
+      "id" : "service-points-users",
+      "version" : "1.0"
+    },
+    {
+      "id": "password-validator",
+      "version": "1.0"
+    },
+    {
+      "id": "notify",
+      "version": "2.0"
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
Are we ready to merge this as the only change needed to mod-users-bl to enable the minimal platform? My write up of the testing I did is here: https://wiki.folio.org/display/FOLIJET/SPIKE%3A+%5BMODUSERBL-155%5D+Investigate+current+implementation+for+using+optional+interfaces

Please read the above doc if you haven't yet but the takeaways are:
* moving everything but core to optional allows for mod-users-bl to be registered without error
* perms aren't a problem for mod-authtoken when the endpoint is called since okapi returns a 404 before going on to call mod-auhtoken
* mod-users-bl handles non existent interfaces gracefully, happily building a partial `CompositeUser` object
* endpoints in mod-users-bl work just fine

One thing that occurs to me that I haven't tried is installing this module with the new optional deps in a non-minimal environment. Also I haven't tested every mod-usersbl endpoint in the minimal setup. Just login and password reset and those work fine. Have also tried it with the new login-with-expiry endpoint. And that also works fine.

This all takes advantage of Adam's excellent [folio-local-run repo](https://github.com/adamdickmeiss/folio-local-run) which has a good readme. Give it a try yourself! All you need is postgres running locally.