### PR TITLE
MODUSERBL-160: RAML: Use type, not schema, to display response JSON spec

### DIFF
--- a/ramls/mod-users-bl.raml
+++ b/ramls/mod-users-bl.raml
@@ -53,7 +53,7 @@ resourceTypes:
       200:
         body:
           application/json:
-            schema: compositeUser
+            type: compositeUser
       400:
         description: "Bad request"
         body:
@@ -84,7 +84,7 @@ resourceTypes:
       description: called when a user has forgotten <<resourceTypeName>>
       body:
         application/json:
-          schema: identifier
+          type: identifier
       responses:
         204:
         400:
@@ -109,7 +109,7 @@ resourceTypes:
         200:
           body:
             application/json:
-              schema: openTransactions
+              type: openTransactions
         400:
           description: "Bad request"
           body:
@@ -137,7 +137,7 @@ resourceTypes:
       200:
         body:
           application/json:
-            schema: compositeUserListObject
+            type: compositeUserListObject
       400:
         description: "Bad request"
         body:
@@ -195,12 +195,12 @@ resourceTypes:
         X-Forwarded-For:
       body:
         application/json:
-          schema: loginCredentials
+          type: loginCredentials
       responses:
         201:
           body:
             application/json:
-              schema: compositeUser
+              type: compositeUser
           headers:
             x-okapi-token:
         400:
@@ -243,7 +243,7 @@ resourceTypes:
               description: "Bad request"
               body:
                 application/json:
-                  schema: errors
+                  type: errors
             401:
               description: "Unauthorized"
               body:


### PR DESCRIPTION
https://issues.folio.org/browse/MODUSERBL-160

In RAML file replace deprecated schema keyword by type keyword.

Otherwise the response JSON spec doesn't show up in the API doc:
https://s3.amazonaws.com/foliodocs/api/mod-users-bl/r/mod-users-bl.html#bl_users_get