### PR TITLE
MODUSERBL-161: Deprecated "meta", "createdDate", "updatedDate"

### DIFF
--- a/ramls/userdata.json
+++ b/ramls/userdata.json
@@ -34,7 +34,7 @@
     },
     "meta": {
       "type": "object",
-      "description": "Metadata object"
+      "description": "Deprecated, data has moved to metadata"
     },
     "proxyFor": {
       "description" : "Deprecated",
@@ -146,12 +146,12 @@
     "createdDate": {
       "type": "string",
       "format": "date-time",
-      "description": "Created date"
+      "description": "Deprecated, data has moved to metadata"
     },
     "updatedDate": {
       "type": "string",
       "format": "date-time",
-      "description": "Updated date"
+      "description": "Deprecated, data has moved to metadata"
     },
     "metadata": {
       "type": "object",


### PR DESCRIPTION
In mod-users "meta", "createdDate", "updatedDate" are deprecated:

https://github.com/folio-org/mod-users/blob/v19.0.0/ramls/userdata.json#L45-L48
https://github.com/folio-org/mod-users/blob/v19.0.0/ramls/userdata.json#L164-L173

In mod-users-bl we need to mention this in ramls/userdata.json.