### PR TITLE
[MODUSERBL-166] - Using tenantId from login response

### DIFF
--- a/ramls/compositeUser.json
+++ b/ramls/compositeUser.json
@@ -31,6 +31,10 @@
       "type": "object",
       "description": "Service point user",
       "$ref": "servicepointsexpandeduser.json"
+    },
+    "tenant": {
+      "description": "Tenant identifier",
+      "type": "string"
     }
   }
 }

--- a/ramls/loginCredentials.json
+++ b/ramls/loginCredentials.json
@@ -17,7 +17,7 @@
       "description": "Password"
     },
     "tenant": {
-      "description": "Tenant identifier",
+      "description": "Parameter for resolving duplicated usernames across tenants.",
       "type": "string"
     }
   }

--- a/ramls/loginCredentials.json
+++ b/ramls/loginCredentials.json
@@ -15,6 +15,10 @@
     "password": {
       "type": "string",
       "description": "Password"
+    },
+    "tenant": {
+      "description": "Tenant identifier",
+      "type": "string"
     }
   }
 }

--- a/src/main/java/org/folio/rest/impl/BLUsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/BLUsersAPI.java
@@ -165,7 +165,7 @@ public class BLUsersAPI implements BlUsers {
     if(isNull(response)){
       //response is null, meaning the previous call failed.
       //set previousFailure flag to true so that we don't send another error response to the client
-      asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+      asyncResultHandler.handle(Future.succeededFuture(
         GetBlUsersByIdByIdResponse.respond500WithTextPlain(
             "response is null from one of the services requested")));
       previousFailure[0] = true;
@@ -190,13 +190,13 @@ public class BLUsersAPI implements BlUsers {
             response.setError(new JsonObject());
           }
           logger.error("No record found for query '" + response.getEndpoint() + "'");
-          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+          asyncResultHandler.handle(Future.succeededFuture(
             GetBlUsersByIdByIdResponse.respond404WithTextPlain("No record found for query '"
                 + response.getEndpoint() + "'")));
         } else if(totalRecords != null && totalRecords > 1 && requireOneResult) {
           logger.error("'" + response.getEndpoint() + "' returns multiple results");
           previousFailure[0] = true;
-          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+          asyncResultHandler.handle(Future.succeededFuture(
             GetBlUsersByIdByIdResponse.respond400WithTextPlain(("'" + response.getEndpoint()
                 + "' returns multiple results"))));
         }
@@ -298,7 +298,7 @@ public class BLUsersAPI implements BlUsers {
       }
     } catch (Exception ex) {
       client.closeClient();
-      asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+      asyncResultHandler.handle(Future.succeededFuture(
         GetBlUsersByIdByIdResponse.respond500WithTextPlain(ex.getLocalizedMessage())));
       return;
     }
@@ -367,7 +367,7 @@ public class BLUsersAPI implements BlUsers {
       }
     } catch (Exception ex) {
       client.closeClient();
-      asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+      asyncResultHandler.handle(Future.succeededFuture(
         GetBlUsersByIdByIdResponse.respond500WithTextPlain(ex.getLocalizedMessage())));
       return;
     }
@@ -482,20 +482,20 @@ public class BLUsersAPI implements BlUsers {
         }
 
         if(mode[0].equals("id")){
-          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+          asyncResultHandler.handle(Future.succeededFuture(
             GetBlUsersByIdByIdResponse.respond200WithApplicationJson(cu)));
         }else if(mode[0].equals("username")){
-          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+          asyncResultHandler.handle(Future.succeededFuture(
             GetBlUsersByUsernameByUsernameResponse.respond200WithApplicationJson(cu)));
         }
       } catch (Exception e) {
         if(!aRequestHasFailed[0]){
           logger.error(e.getMessage(), e);
           if(mode[0].equals("id")){
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+            asyncResultHandler.handle(Future.succeededFuture(
               GetBlUsersByIdByIdResponse.respond500WithTextPlain(e.getLocalizedMessage())));
           }else if(mode[0].equals("username")){
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+            asyncResultHandler.handle(Future.succeededFuture(
               GetBlUsersByUsernameByUsernameResponse.respond500WithTextPlain(e.getLocalizedMessage())));
           }
         }
@@ -533,7 +533,7 @@ public class BLUsersAPI implements BlUsers {
       userIdResponse[0] = client.request(userUrl.toString(), okapiHeaders);
     } catch (Exception ex) {
       client.closeClient();
-      asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+      asyncResultHandler.handle(Future.succeededFuture(
         GetBlUsersByIdByIdResponse.respond500WithTextPlain(ex.getLocalizedMessage())));
       return;
     }
@@ -586,7 +586,7 @@ public class BLUsersAPI implements BlUsers {
         composite.mapFrom(userResponse, "users[*]", "compositeUser", "users", true);
         if(composite.getBody().isEmpty()){
           if(!aRequestHasFailed[0]){
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+            asyncResultHandler.handle(Future.succeededFuture(
               GetBlUsersResponse.respond200WithApplicationJson(cu)));
           }
           aRequestHasFailed[0] = true;
@@ -627,12 +627,12 @@ public class BLUsersAPI implements BlUsers {
         List<CompositeUser> cuol = (List<CompositeUser>)Response.convertToPojo(composite.getBody().getJsonArray("compositeUser"), CompositeUser.class);
         cu.setCompositeUsers(cuol);
         if(!aRequestHasFailed[0]){
-          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+          asyncResultHandler.handle(Future.succeededFuture(
             GetBlUsersResponse.respond200WithApplicationJson(cu)));
         }
       } catch (Exception e) {
         if(!aRequestHasFailed[0]){
-          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+          asyncResultHandler.handle(Future.succeededFuture(
             GetBlUsersResponse.respond500WithTextPlain(e.getLocalizedMessage())));
         }
         logger.error(e.getMessage(), e);
@@ -813,7 +813,7 @@ public class BLUsersAPI implements BlUsers {
     }
 
     if (entity == null || entity.getUsername() == null || entity.getPassword() == null) {
-      asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+      asyncResultHandler.handle(Future.succeededFuture(
         PostBlUsersLoginResponse.respond400WithTextPlain("Improperly formatted request")));
     } else {
       HttpClientInterface clientForLogin = HttpClientFactory.getHttpClient(okapiURL, okapiHeaders.get(OKAPI_TENANT_HEADER));
@@ -847,7 +847,7 @@ public class BLUsersAPI implements BlUsers {
               getUserWithPerms(expandPerms, okapiHeaders, asyncResultHandler, userUrl, finalInclude, token, tenant, client);
             } catch (Exception e) {
               client.closeClient();
-              asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+              asyncResultHandler.handle(Future.succeededFuture(
                 PostBlUsersLoginResponse.respond500WithTextPlain(e.getLocalizedMessage())));
             } finally {
               clientForLogin.closeClient();
@@ -855,13 +855,13 @@ public class BLUsersAPI implements BlUsers {
           })
           .exceptionally(throwable -> {
             clientForLogin.closeClient();
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+            asyncResultHandler.handle(Future.succeededFuture(
               PostBlUsersLoginResponse.respond500WithTextPlain(throwable.getLocalizedMessage())));
             return null;
           });
       } catch (Exception ex) {
         clientForLogin.closeClient();
-        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+        asyncResultHandler.handle(Future.succeededFuture(
           PostBlUsersLoginResponse.respond500WithTextPlain(ex.getLocalizedMessage())));
       }
     }
@@ -912,7 +912,7 @@ public class BLUsersAPI implements BlUsers {
             requestedIncludes.add(expandSPUResponse);
           } catch (Exception ex) {
             client.closeClient();
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+            asyncResultHandler.handle(Future.succeededFuture(
               PostBlUsersLoginResponse.respond500WithTextPlain(ex.getLocalizedMessage())));
           }
         }
@@ -1017,13 +1017,13 @@ public class BLUsersAPI implements BlUsers {
           }
 
           if(!aRequestHasFailed[0]){
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+            asyncResultHandler.handle(Future.succeededFuture(
               PostBlUsersLoginResponse.respond201WithApplicationJson(cu,
                 PostBlUsersLoginResponse.headersFor201().withXOkapiToken(token))));
           }
         } catch (Exception e) {
           if(!aRequestHasFailed[0]){
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+            asyncResultHandler.handle(Future.succeededFuture(
               PostBlUsersLoginResponse.respond500WithTextPlain(e.getLocalizedMessage())));
           }
           logger.error(e.getMessage(), e);
@@ -1151,8 +1151,8 @@ public class BLUsersAPI implements BlUsers {
    * @param okapiHeaders
    * @return
    */
-  private io.vertx.core.Future<User> locateUserByAlias(List<String> fieldAliasList, Identifier entity,
-                                                       java.util.Map<String, String> okapiHeaders, String errorKey) {
+  private Future<User> locateUserByAlias(List<String> fieldAliasList, Identifier entity,
+                                                       Map<String, String> okapiHeaders, String errorKey) {
     Promise<User> asyncResult = Promise.promise();
     getLocateUserFields(fieldAliasList, okapiHeaders).onComplete(locateUserFieldsAR -> {
       if (!locateUserFieldsAR.succeeded()) {
@@ -1223,7 +1223,7 @@ public class BLUsersAPI implements BlUsers {
    * { "module" : "USERSBL", "configName" : "fogottenData", "code" : "email", "description" : "if true personal.email will be used for forgot password and forgot user name search", "default" : false, "enabled" : true, "value" : "personal.email" }
    */
   @Override
-  public void postBlUsersForgottenPassword(Identifier entity, java.util.Map<String, String>okapiHeaders, io.vertx.core.Handler<io.vertx.core.AsyncResult<javax.ws.rs.core.Response>>asyncResultHandler, Context vertxContext) {
+  public void postBlUsersForgottenPassword(Identifier entity, Map<String, String>okapiHeaders, Handler<AsyncResult<javax.ws.rs.core.Response>>asyncResultHandler, Context vertxContext) {
     OkapiConnectionParams connectionParams = new OkapiConnectionParams(okapiHeaders);
     locateUserByAlias(Arrays.asList(LOCATE_USER_USERNAME, LOCATE_USER_PHONE_NUMBER, LOCATE_USER_EMAIL), entity, okapiHeaders, FORGOTTEN_PASSWORD_ERROR_KEY)
       .compose(user -> passwordResetLinkService.sendPasswordRestLink(user.getId(), connectionParams))
@@ -1234,7 +1234,7 @@ public class BLUsersAPI implements BlUsers {
   }
 
   @Override
-  public void postBlUsersForgottenUsername(Identifier entity, java.util.Map<String, String>okapiHeaders, io.vertx.core.Handler<io.vertx.core.AsyncResult<javax.ws.rs.core.Response>>asyncResultHandler, Context vertxContext) {
+  public void postBlUsersForgottenUsername(Identifier entity, Map<String, String>okapiHeaders, Handler<AsyncResult<javax.ws.rs.core.Response>>asyncResultHandler, Context vertxContext) {
     OkapiConnectionParams connectionParams = new OkapiConnectionParams(okapiHeaders);
     locateUserByAlias(Arrays.asList(LOCATE_USER_PHONE_NUMBER, LOCATE_USER_EMAIL), entity, okapiHeaders, FORGOTTEN_USERNAME_ERROR_KEY)
       .compose(user -> {

--- a/src/main/java/org/folio/rest/impl/BLUsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/BLUsersAPI.java
@@ -845,7 +845,7 @@ public class BLUsersAPI implements BlUsers {
 
             try {
               getUserWithPerms(expandPerms, okapiHeaders, asyncResultHandler, userUrl, finalInclude, token, tenant, client);
-            } catch (Exception e) { //NOSONAR
+            } catch (Exception e) {
               client.closeClient();
               asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
                 PostBlUsersLoginResponse.respond500WithTextPlain(e.getLocalizedMessage())));

--- a/src/test/java/org/folio/rest/BLUsersAPITest.java
+++ b/src/test/java/org/folio/rest/BLUsersAPITest.java
@@ -31,6 +31,8 @@ import java.util.Base64;
 import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
+import static org.folio.rest.MockOkapi.getToken;
+import static org.folio.rest.MockOkapi.getTokenWithoutUserId;
 import static org.hamcrest.Matchers.equalTo;
 
 
@@ -257,6 +259,39 @@ public class BLUsersAPITest {
             statusCode(200).
             body("compositeUsers.size()", equalTo(5),
                  "compositeUsers[0].users.username", equalTo("maxi"));
+  }
+
+  @Test
+  public void getBlUsersSelf(TestContext context) {
+    Header header = new Header(RestVerticle.OKAPI_HEADER_TOKEN, getToken(USER_ID, "maxi", "diku"));
+    given().
+        spec(okapi).port(port).header(header).
+      when().
+        get("/bl-users/_self").
+      then().
+        statusCode(200);
+  }
+
+  @Test
+  public void getBlUsersSelfWithoutToken(TestContext context) {
+    Header header = new Header(RestVerticle.OKAPI_HEADER_TOKEN, "");
+    given().
+      spec(okapi).port(port).header(header).
+      when().
+      get("/bl-users/_self").
+      then().
+      statusCode(400);
+  }
+
+  @Test
+  public void getBlUsersSelfWithoutUserId(TestContext context) {
+    Header header = new Header(RestVerticle.OKAPI_HEADER_TOKEN, getTokenWithoutUserId("maxi", "diku"));
+    given().
+      spec(okapi).port(port).header(header).
+      when().
+      get("/bl-users/_self").
+      then().
+      statusCode(200);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/GeneratePasswordRestLinkTest.java
+++ b/src/test/java/org/folio/rest/GeneratePasswordRestLinkTest.java
@@ -96,7 +96,7 @@ public class GeneratePasswordRestLinkTest {
       .setContentType(ContentType.JSON)
       .setBaseUri("http://localhost:" + port)
       .addHeader(RestVerticle.OKAPI_HEADER_TENANT, TENANT)
-      .addHeader(RestVerticle.OKAPI_HEADER_TOKEN, getToken())
+      .addHeader(RestVerticle.OKAPI_HEADER_TOKEN, getToken(UUID.randomUUID().toString(),"admin", "diku"))
       .build();
   }
 

--- a/src/test/java/org/folio/rest/HeadersForwardingTest.java
+++ b/src/test/java/org/folio/rest/HeadersForwardingTest.java
@@ -252,6 +252,69 @@ public class HeadersForwardingTest {
   }
 
   @Test
+  public void testPostBlUsersLoginNullResponse() {
+    LoginCredentials credentials = new LoginCredentials();
+    credentials.setUsername(USERNAME);
+    credentials.setPassword("password");
+
+    WireMock.stubFor(post(URL_AUTH_LOGIN)
+      .willReturn(null));
+
+    RestAssured
+      .given()
+      .spec(spec)
+      .header(new Header(BLUsersAPI.X_FORWARDED_FOR_HEADER, IP))
+      .body(JsonObject.mapFrom(credentials).encode())
+      .when()
+      .post("/bl-users/login")
+      .then()
+      .statusCode(500);
+
+    WireMock.verify(1, postRequestedFor(urlPathEqualTo(URL_AUTH_LOGIN)));
+    WireMock.verify(0, postRequestedFor(urlPathEqualTo("/perms/users")));
+  }
+
+  @Test
+  public void testPostBlUsersLoginWithoutUsername() {
+    LoginCredentials credentials = new LoginCredentials();
+    credentials.setUsername(null);
+    credentials.setPassword("password");
+
+    RestAssured
+      .given()
+      .spec(spec)
+      .header(new Header(BLUsersAPI.X_FORWARDED_FOR_HEADER, IP))
+      .body(JsonObject.mapFrom(credentials).encode())
+      .when()
+      .post("/bl-users/login")
+      .then()
+      .statusCode(400);
+
+    WireMock.verify(0, postRequestedFor(urlPathEqualTo(URL_AUTH_LOGIN)));
+    WireMock.verify(0, postRequestedFor(urlPathEqualTo("/perms/users")));
+  }
+
+  @Test
+  public void testPostBlUsersLoginWithoutPassword() {
+    LoginCredentials credentials = new LoginCredentials();
+    credentials.setUsername(USERNAME);
+    credentials.setPassword(null);
+
+    RestAssured
+      .given()
+      .spec(spec)
+      .header(new Header(BLUsersAPI.X_FORWARDED_FOR_HEADER, IP))
+      .body(JsonObject.mapFrom(credentials).encode())
+      .when()
+      .post("/bl-users/login")
+      .then()
+      .statusCode(400);
+
+    WireMock.verify(0, postRequestedFor(urlPathEqualTo(URL_AUTH_LOGIN)));
+    WireMock.verify(0, postRequestedFor(urlPathEqualTo("/perms/users")));
+  }
+
+  @Test
   public void testPostBlUsersLoginIncorrectPermissions() {
     LoginCredentials credentials = new LoginCredentials();
     credentials.setUsername(USERNAME);

--- a/src/test/java/org/folio/rest/HeadersForwardingTest.java
+++ b/src/test/java/org/folio/rest/HeadersForwardingTest.java
@@ -229,7 +229,7 @@ public class HeadersForwardingTest {
   }
 
   @Test
-  public void testPostBlUsersLoginWithNullToken1() {
+  public void testPostBlUsersLoginWithError() {
     LoginCredentials credentials = new LoginCredentials();
     credentials.setUsername(USERNAME);
     credentials.setPassword("password");

--- a/src/test/java/org/folio/rest/HeadersForwardingTest.java
+++ b/src/test/java/org/folio/rest/HeadersForwardingTest.java
@@ -229,6 +229,29 @@ public class HeadersForwardingTest {
   }
 
   @Test
+  public void testPostBlUsersLoginWithNullToken1() {
+    LoginCredentials credentials = new LoginCredentials();
+    credentials.setUsername(USERNAME);
+    credentials.setPassword("password");
+
+    WireMock.stubFor(post(URL_AUTH_LOGIN)
+      .willReturn(WireMock.okJson(JsonObject.mapFrom(credentials).encode()).withStatus(422)));
+
+    RestAssured
+      .given()
+      .spec(spec)
+      .header(new Header(BLUsersAPI.X_FORWARDED_FOR_HEADER, IP))
+      .body(JsonObject.mapFrom(credentials).encode())
+      .when()
+      .post("/bl-users/login")
+      .then()
+      .statusCode(422);
+
+    WireMock.verify(1, postRequestedFor(urlPathEqualTo(URL_AUTH_LOGIN)));
+    WireMock.verify(0, postRequestedFor(urlPathEqualTo("/perms/users")));
+  }
+
+  @Test
   public void testPostBlUsersLoginIncorrectPermissions() {
     LoginCredentials credentials = new LoginCredentials();
     credentials.setUsername(USERNAME);

--- a/src/test/java/org/folio/rest/MockOkapi.java
+++ b/src/test/java/org/folio/rest/MockOkapi.java
@@ -62,7 +62,6 @@ public class MockOkapi extends AbstractVerticle {
   private static final String REQUESTS_ENDPOINT = "/request-storage/request";
   private static final String ACCOUNTS_ENDPOINT = "/accounts";
   private static final String MANUAL_BLOCKS_ENDPOINT = "/manualblocks";
-  private static final String ADMIN_USER_ID = UUID.randomUUID().toString();
 
   @Override
   public void start(Promise<Void> future) {
@@ -698,11 +697,29 @@ public class MockOkapi extends AbstractVerticle {
     return newList;
   }
 
-  public static String getToken() {
+  public static String getToken(String userId, String username, String tenant) {
     final String payload = new JsonObject()
-      .put("user_id", ADMIN_USER_ID)
-      .put("sub", "admin")
-      .put("tenant", "diku")
+      .put("user_id", userId)
+      .put("sub", username)
+      .put("tenant", tenant)
+      .toString();
+
+    return "header." + Base64.getEncoder().encodeToString(payload.getBytes()) + ".verify";
+  }
+
+  public static String getTokenWithoutUserId(String username, String tenant) {
+    final String payload = new JsonObject()
+      .put("sub", username)
+      .put("tenant", tenant)
+      .toString();
+
+    return "header." + Base64.getEncoder().encodeToString(payload.getBytes()) + ".verify";
+  }
+
+  public static String getTokenWithoutTenant(String userId, String username) {
+    final String payload = new JsonObject()
+      .put("user_id", userId)
+      .put("sub", username)
       .toString();
 
     return "header." + Base64.getEncoder().encodeToString(payload.getBytes()) + ".verify";


### PR DESCRIPTION
We need to support changes made in mod-login to have succesfull login in consortia setup [MODLOGIN-205](https://issues.folio.org/browse/MODLOGIN-205). The login API retrieves the right tenant for the user, and we should use this tenant to call the user API.

_self endpoint is changed to support retrieving shadow user information after context (affiliation is switched). What does it mean? When affiliation is changed UI sends _self  request to refresh user data (permissions, service points etc), in `master branch` implementation _self relies on username in token to find user, but for cross-tenant usage username is different for all shadow users, as a result we need to use parameter that is the same for all users (main and shadow) across tenants which is uuid. Additionally we keep previous search by username in case of empty tokens, username and UNDEFINED_USER (okapi doesn't provide possibility to have endpoints without permissions, but for authenticated users, so `master branch` and changes in this branch solve this problem by throwing error as users in non-client tokens can't be found)