### PR TITLE
MODUSERBL-180 Module needs to respond 404 when 404 is received from /authn/login and /token endpoints

### DIFF
--- a/src/main/java/org/folio/rest/client/impl/AuthTokenClientImpl.java
+++ b/src/main/java/org/folio/rest/client/impl/AuthTokenClientImpl.java
@@ -6,6 +6,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import org.apache.http.HttpStatus;
 import org.folio.rest.client.AuthTokenClient;
+import org.folio.rest.exception.TokenNotFoundException;
 import org.folio.rest.exception.OkapiModuleClientException;
 import org.folio.rest.impl.BLUsersAPI;
 import org.folio.rest.util.OkapiConnectionParams;
@@ -32,6 +33,10 @@ public class AuthTokenClientImpl implements AuthTokenClient {
             return response.getResponse().headers().get(BLUsersAPI.OKAPI_TOKEN_HEADER);
           case HttpStatus.SC_CREATED:
             return response.getJson().getString("token");
+          case HttpStatus.SC_NOT_FOUND:
+            String notFoundLogMessage =
+                    String.format("Token not found. Status: %d, body: %s", response.getCode(), response.getBody());
+            throw new TokenNotFoundException(notFoundLogMessage);
           default:
             String logMessage =
               String.format("Error when signing token. Status: %d, body: %s", response.getCode(), response.getBody());

--- a/src/main/java/org/folio/rest/exception/TokenNotFoundException.java
+++ b/src/main/java/org/folio/rest/exception/TokenNotFoundException.java
@@ -1,0 +1,13 @@
+package org.folio.rest.exception;
+
+public class TokenNotFoundException extends RuntimeException {
+
+    public TokenNotFoundException() {
+        super();
+    }
+
+    public TokenNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/org/folio/rest/exception/TokenNotFoundException.java
+++ b/src/main/java/org/folio/rest/exception/TokenNotFoundException.java
@@ -2,10 +2,6 @@ package org.folio.rest.exception;
 
 public class TokenNotFoundException extends RuntimeException {
 
-    public TokenNotFoundException() {
-        super();
-    }
-
     public TokenNotFoundException(String message) {
         super(message);
     }

--- a/src/main/java/org/folio/rest/util/ExceptionHelper.java
+++ b/src/main/java/org/folio/rest/util/ExceptionHelper.java
@@ -3,6 +3,7 @@ package org.folio.rest.util;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.http.HttpStatus;
+import org.folio.rest.exception.TokenNotFoundException;
 import org.folio.rest.exception.UnprocessableEntityException;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
@@ -15,7 +16,7 @@ import java.util.stream.Collectors;
 
 public final class ExceptionHelper {
 
-  private static final Logger LOG = LogManager.getLogger(ExceptionHelper.class); 
+  private static final Logger LOG = LogManager.getLogger(ExceptionHelper.class);
 
   private ExceptionHelper() {
   }
@@ -44,6 +45,11 @@ public final class ExceptionHelper {
         .type(MediaType.TEXT_PLAIN)
         .entity(throwable.getMessage())
         .build();
+    } else if(throwable.getClass() == TokenNotFoundException.class){
+      return Response.status(HttpStatus.SC_NOT_FOUND)
+              .type(MediaType.TEXT_PLAIN)
+              .entity(throwable.getMessage())
+              .build();
     }
     LOG.error(throwable.getMessage(), throwable);
     return Response.status(HttpStatus.SC_INTERNAL_SERVER_ERROR)

--- a/src/main/java/org/folio/rest/util/ExceptionHelper.java
+++ b/src/main/java/org/folio/rest/util/ExceptionHelper.java
@@ -45,7 +45,7 @@ public final class ExceptionHelper {
         .type(MediaType.TEXT_PLAIN)
         .entity(throwable.getMessage())
         .build();
-    } else if(throwable.getClass() == TokenNotFoundException.class){
+    } else if (throwable.getClass() == TokenNotFoundException.class){
       return Response.status(HttpStatus.SC_NOT_FOUND)
               .type(MediaType.TEXT_PLAIN)
               .entity(throwable.getMessage())


### PR DESCRIPTION
## Purpose
The purpose of this PR is to add a 404 response for /auth/login and /token endpoints

## Approach
Added 404 response in AuthTokenClientImpl class for /token endpoint and for /auth/login they are already handling 404 response.