### PR TITLE
MODUSERBL-189 Missing interface dependency in module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -251,6 +251,10 @@
     {
       "id": "password-validator",
       "version": "1.0"
+    },
+    {
+      "id": "request-storage",
+      "version": "6.0"
     }
   ],
   "optional": [


### PR DESCRIPTION
Purpose:
The purpose of the PR is to implement - https://folio-org.atlassian.net/browse/MODUSERBL-189 

Approach:
request-storage dependency with version 6.0 is added in Module descriptor of mod-users-bl .