### PR TITLE
MODUSERBL-213 Adding missed interface dependency in module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -282,6 +282,10 @@
     {
       "id": "request-storage",
       "version": "6.1"
+    },
+    {
+      "id": "request-preference-storage",
+      "version": "2.0"
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
## Purpose
The purpose of the PR is to fix MODUSERBL-213

## Approach
Added the missed interface dependency reported in the jira.