### PR TITLE
MODUSERBL-175: Remove legacy tokens

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "users-bl",
-      "version": "6.1",
+      "version": "7.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -23,21 +23,6 @@
           "pathPattern" : "/bl-users/_self",
           "permissionsRequired" : [],
           "modulePermissions": [
-            "users.item.get",
-            "users.collection.get",
-            "perms.users.get",
-            "usergroups.item.get",
-            "inventory-storage.service-points-users.collection.get",
-            "inventory-storage.service-points-users.item.get",
-            "inventory-storage.service-points.collection.get",
-            "inventory-storage.service-points.item.get"
-          ]
-        },
-        {
-          "methods" : [ "POST" ],
-          "pathPattern" : "/bl-users/login",
-          "permissionsRequired" : [],
-          "modulePermissions" : [
             "users.item.get",
             "users.collection.get",
             "perms.users.get",
@@ -243,7 +228,7 @@
     },
     {
       "id" : "login",
-      "version" : "7.3"
+      "version" : "8.0"
     },
     {
       "id": "authtoken",

--- a/ramls/mod-users-bl.raml
+++ b/ramls/mod-users-bl.raml
@@ -186,38 +186,6 @@ resourceTypes:
         type: { compositeOpenTransactionsResource: { "typeName" : "username" } }
   /_self:
     type: { compositeUserResource: { "typeName" : "self reference" } }
-  /login:
-    post:
-      description: Allow a new user to login and return an authtoken, along with a composite user record. Deprecated and will be removed in a future release. Please use /login-with-expiry.
-      is: [permissionsExpandable, includeable]
-      headers:
-        User-Agent:
-        X-Forwarded-For:
-      body:
-        application/json:
-          type: loginCredentials
-      responses:
-        201:
-          body:
-            application/json:
-              type: compositeUser
-          headers:
-            x-okapi-token:
-        400:
-          description: "Bad request"
-          body:
-            text/plain:
-              example: "Bad request"
-        422:
-          description: "Unprocessable Entity"
-          body:
-            application/json:
-              type: errors
-        500:
-          description: "Internal server error"
-          body:
-            text/plain:
-              example: "Internal server error"
   /login-with-expiry:
     post:
       description: |

--- a/src/main/java/org/folio/rest/impl/BLUsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/BLUsersAPI.java
@@ -139,7 +139,6 @@ public class BLUsersAPI implements BlUsers {
   private static final String UNDEFINED_USER = "UNDEFINED_USER__";
 
   private static final String LOGIN_ENDPOINT = "/authn/login-with-expiry";
-  private static final String LOGIN_ENDPOINT_LEGACY = "/authn/login";
   private static final String FOLIO_ACCESS_TOKEN = "folioAccessToken";
   private static final String SET_COOKIE_HEADER = "Set-Cookie";
 
@@ -853,14 +852,6 @@ public class BLUsersAPI implements BlUsers {
         LOGIN_ENDPOINT, this::loginResponse);
   }
 
-  @Override
-  public void postBlUsersLogin(boolean expandPerms, List<String> include, String userAgent, String xForwardedFor,
-      LoginCredentials entity, Map<String, String> okapiHeaders, Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler,
-      Context vertxContext) {
-    doPostBlUsersLogin(expandPerms, include, userAgent, xForwardedFor, entity, okapiHeaders, asyncResultHandler,
-        LOGIN_ENDPOINT_LEGACY, this::loginResponseLegacy);
-  }
-
   @SuppressWarnings("java:S1874")
   private void doPostBlUsersLogin(boolean expandPerms, List<String> include, String userAgent, String xForwardedFor, //NOSONAR
       LoginCredentials entity, Map<String, String> okapiHeaders, Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler,
@@ -879,7 +870,7 @@ public class BLUsersAPI implements BlUsers {
 
     if (entity == null || entity.getUsername() == null || entity.getPassword() == null) {
       asyncResultHandler.handle(Future.succeededFuture(
-        PostBlUsersLoginResponse.respond400WithTextPlain("Improperly formatted request")));
+        PostBlUsersLoginWithExpiryResponse.respond400WithTextPlain("Improperly formatted request")));
     } else {
       HttpClientInterface clientForLogin = HttpClientFactory.getHttpClient(okapiURL, okapiHeaders.get(OKAPI_TENANT_HEADER));
       String moduleURL = "/authn/login";
@@ -913,7 +904,7 @@ public class BLUsersAPI implements BlUsers {
             } catch (Exception e) {
               client.closeClient();
               asyncResultHandler.handle(Future.succeededFuture(
-                PostBlUsersLoginResponse.respond500WithTextPlain(e.getLocalizedMessage())));
+                PostBlUsersLoginWithExpiryResponse.respond500WithTextPlain(e.getLocalizedMessage())));
             } finally {
               clientForLogin.closeClient();
             }
@@ -921,13 +912,13 @@ public class BLUsersAPI implements BlUsers {
           .exceptionally(throwable -> {
             clientForLogin.closeClient();
             asyncResultHandler.handle(Future.succeededFuture(
-              PostBlUsersLoginResponse.respond500WithTextPlain(throwable.getLocalizedMessage())));
+              PostBlUsersLoginWithExpiryResponse.respond500WithTextPlain(throwable.getLocalizedMessage())));
             return null;
           });
       } catch (Exception ex) {
         clientForLogin.closeClient();
         asyncResultHandler.handle(Future.succeededFuture(
-          PostBlUsersLoginResponse.respond500WithTextPlain(ex.getLocalizedMessage())));
+          PostBlUsersLoginWithExpiryResponse.respond500WithTextPlain(ex.getLocalizedMessage())));
       }
     }
   }
@@ -999,7 +990,7 @@ public class BLUsersAPI implements BlUsers {
           } catch (Exception ex) {
             client.closeClient();
             asyncResultHandler.handle(Future.succeededFuture(
-              PostBlUsersLoginResponse.respond500WithTextPlain(ex.getLocalizedMessage())));
+              PostBlUsersLoginWithExpiryResponse.respond500WithTextPlain(ex.getLocalizedMessage())));
           }
         }
       }
@@ -1084,7 +1075,7 @@ public class BLUsersAPI implements BlUsers {
         } catch (Exception e) {
           if(!aRequestHasFailed[0]){
             asyncResultHandler.handle(Future.succeededFuture(
-              PostBlUsersLoginResponse.respond500WithTextPlain(e.getLocalizedMessage())));
+              PostBlUsersLoginWithExpiryResponse.respond500WithTextPlain(e.getLocalizedMessage())));
           }
           logger.error(e.getMessage(), e);
         } finally {
@@ -1124,13 +1115,6 @@ public class BLUsersAPI implements BlUsers {
         cu.setServicePointsUser(spu);
       }
     }
-  }
-
-  @SuppressWarnings("java:S1874")
-  private javax.ws.rs.core.Response loginResponseLegacy(Response loginResponse, CompositeUser cu) {
-    String token = String.valueOf(loginResponse.getHeaders().get(OKAPI_TOKEN_HEADER));
-    return PostBlUsersLoginResponse.respond201WithApplicationJson(cu,
-      PostBlUsersLoginResponse.headersFor201().withXOkapiToken(token));
   }
 
   @SuppressWarnings("java:S1874")


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODUSERBL-175

Summary of changes:
* Remove `authn/login` from RAML
* Return PostBlUsersLoginWithExpiryResponse instead of PostBlUsersLoginResponse from routes.
* Update all legacy tests to use expiry endpoint
* Revise module descriptor, bumping up major version and mod-login version